### PR TITLE
download submodule using HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "vcpkg"]
 	path = vcpkg
-	url = git@github.com:microsoft/vcpkg.git
+	url = https://github.com/microsoft/vcpkg.git


### PR DESCRIPTION
I got "git@github.com: Permission denied (publickey)." when trying to init submodules of your repo. I'm not sure what's wrong as I have working SSH authentication for my private repos. The problem is probably something misconfigured on my machine, but generally speaking, there's no reason to require users to have an SSH setup at all, just to download a public dependency. This PR resolves this issue by changing the vcpkg source to HTTPS.