### PR TITLE
Add TooManyCooks and concurrencpp benchmarks

### DIFF
--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -100,7 +100,10 @@ endif()
 target_compile_definitions(benchmark PRIVATE TMC_WORK_ITEM=CORO)
 target_compile_definitions(benchmark PRIVATE TMC_PRIORITY_COUNT=1)
 target_compile_definitions(benchmark PRIVATE TMC_USE_HWLOC)
-target_compile_definitions(benchmark PRIVATE TMC_TRIVIAL_TASK)
+
+# TMC_TRIVIAL_TASK causes asserts to fail in debug builds...
+
+# target_compile_definitions(benchmark PRIVATE TMC_TRIVIAL_TASK)
 
 target_include_directories(benchmark PRIVATE ${tmc_SOURCE_DIR}/include)
 

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -17,25 +17,21 @@ find_package(benchmark REQUIRED)
 
 file(GLOB_RECURSE BENCH_C_SOURCES CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/source/**/*.c")
 file(GLOB_RECURSE BENCH_SERIAL CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/source/**/serial.cpp")
-file(GLOB_RECURSE BENCH_LIBFORK CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/source/**/libfork.cpp")
-
-add_executable(benchmark 
-  ${BENCH_C_SOURCES}
-  ${BENCH_SERIAL} 
-  ${BENCH_LIBFORK} 
-  ${CMAKE_CURRENT_SOURCE_DIR}/source/calibrate.cpp
+file(GLOB_RECURSE BENCH_LIBFORK CONFIGURE_DEPENDS
+     "${CMAKE_CURRENT_SOURCE_DIR}/source/**/libfork.cpp"
 )
 
-target_link_libraries(benchmark 
-    PRIVATE 
-        libfork::libfork 
-        benchmark::benchmark_main
+add_executable(
+  benchmark ${BENCH_C_SOURCES} ${BENCH_SERIAL} ${BENCH_LIBFORK}
+            ${CMAKE_CURRENT_SOURCE_DIR}/source/calibrate.cpp
 )
+
+target_link_libraries(benchmark PRIVATE libfork::libfork benchmark::benchmark_main)
 
 option(LF_NO_CHECK "Disable benchmark verifications to speed up the benchmarks " OFF)
 
 if(LF_NO_CHECK)
-    target_compile_definitions(benchmark PRIVATE LF_NO_CHECK)
+  target_compile_definitions(benchmark PRIVATE LF_NO_CHECK)
 endif()
 
 # --- Optional dependencies ---
@@ -43,52 +39,80 @@ endif()
 find_package(TBB QUIET)
 
 if(TBB_FOUND)
-    file(GLOB_RECURSE BENCH_TBB CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/source/**/tbb.cpp")
-    target_sources(benchmark PRIVATE ${BENCH_TBB})
-    target_link_libraries(benchmark PRIVATE TBB::tbb)
+  file(GLOB_RECURSE BENCH_TBB CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/source/**/tbb.cpp")
+  target_sources(benchmark PRIVATE ${BENCH_TBB})
+  target_link_libraries(benchmark PRIVATE TBB::tbb)
 else()
-    message(WARNING "TBB not found, skipping TBB benchmarks")
+  message(WARNING "TBB not found, skipping TBB benchmarks")
 endif()
 
 find_package(OpenMP QUIET)
 
 if(OpenMP_FOUND)
-    file(GLOB_RECURSE BENCH_OpenMP CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/source/**/omp.cpp")
-    target_sources(benchmark PRIVATE ${BENCH_OpenMP})
-    target_link_libraries(benchmark PRIVATE OpenMP::OpenMP_CXX )
+  file(GLOB_RECURSE BENCH_OpenMP CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/source/**/omp.cpp")
+  target_sources(benchmark PRIVATE ${BENCH_OpenMP})
+  target_link_libraries(benchmark PRIVATE OpenMP::OpenMP_CXX)
 else()
-    message(WARNING "OpenMP not found, skipping OpenMP benchmarks")
+  message(WARNING "OpenMP not found, skipping OpenMP benchmarks")
 endif()
 
 find_package(Taskflow QUIET)
 
 if(Taskflow_FOUND)
-    file(GLOB_RECURSE BENCH_Taskflow CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/source/**/taskflow.cpp")
-    target_sources(benchmark PRIVATE ${BENCH_Taskflow})
-    target_link_libraries(benchmark PRIVATE Taskflow::Taskflow)
+  file(GLOB_RECURSE BENCH_Taskflow CONFIGURE_DEPENDS
+       "${CMAKE_CURRENT_SOURCE_DIR}/source/**/taskflow.cpp"
+  )
+  target_sources(benchmark PRIVATE ${BENCH_Taskflow})
+  target_link_libraries(benchmark PRIVATE Taskflow::Taskflow)
 else()
-    message(WARNING "Taskflow not found, skipping Taskflow benchmarks")
+  message(WARNING "Taskflow not found, skipping Taskflow benchmarks")
 endif()
 
 find_package(concurrencpp QUIET)
 
 if(concurrencpp_FOUND)
-    file(GLOB_RECURSE BENCH_concurrencpp CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/source/**/ccpp.cpp")
-    target_sources(benchmark PRIVATE ${BENCH_concurrencpp})
-    target_link_libraries(benchmark PRIVATE concurrencpp::concurrencpp)
+  file(GLOB_RECURSE BENCH_concurrencpp CONFIGURE_DEPENDS
+       "${CMAKE_CURRENT_SOURCE_DIR}/source/**/ccpp.cpp"
+  )
+  target_sources(benchmark PRIVATE ${BENCH_concurrencpp})
+  target_link_libraries(benchmark PRIVATE concurrencpp::concurrencpp)
 else()
-    message(WARNING "concurrencpp not found, skipping concurrencpp benchmarks")
+  message(WARNING "concurrencpp not found, skipping concurrencpp benchmarks")
 endif()
+
+# TMC
+
+include(FetchContent)
+
+FetchContent_Declare(
+  tmc
+  GIT_REPOSITORY https://github.com/tzcnt/TooManyCooks.git
+  GIT_TAG df81ef9f493e88df6b7ac08f0490e968866fa10b
+  CONFIGURE_COMMAND "" BUILD_COMMAND ""
+)
+
+FetchContent_GetProperties(tmc)
+
+if(NOT tmc_POPULATED)
+  FetchContent_Populate(tmc)
+endif()
+
+target_compile_definitions(benchmark PRIVATE TMC_WORK_ITEM=CORO)
+target_compile_definitions(benchmark PRIVATE TMC_PRIORITY_COUNT=1)
+target_compile_definitions(benchmark PRIVATE TMC_USE_HWLOC)
+target_compile_definitions(benchmark PRIVATE TMC_TRIVIAL_TASK)
+
+target_include_directories(benchmark PRIVATE ${tmc_SOURCE_DIR}/include)
+
+file(GLOB_RECURSE BENCH_tmc CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/source/**/tmc.cpp")
+
+target_sources(benchmark PRIVATE ${BENCH_tmc} ${CMAKE_CURRENT_SOURCE_DIR}/source/tmc.cpp)
 
 # ---- Coro benchmarks ----
 
 add_executable(coro_bench ${CMAKE_CURRENT_SOURCE_DIR}/source/coroutine/incremental.cpp)
 
-target_link_libraries(coro_bench 
-    PRIVATE 
-        libfork::libfork 
-        benchmark::benchmark_main
-)
+target_link_libraries(coro_bench PRIVATE libfork::libfork benchmark::benchmark_main)
 
 # ---- End-of-file commands ----
 add_folders(benchmarks)

--- a/bench/source/fib/ccpp.cpp
+++ b/bench/source/fib/ccpp.cpp
@@ -25,7 +25,10 @@ void fib_ccpp(benchmark::State &state) {
   state.counters["green_threads"] = state.range(0);
   state.counters["fib(n)"] = work;
 
-  concurrencpp::runtime runtime;
+  concurrencpp::runtime_options opt;
+  opt.max_cpu_threads = state.range(0);
+  concurrencpp::runtime runtime(opt);
+
   auto tpe = runtime.thread_pool_executor();
 
   volatile int secret = work;

--- a/bench/source/fib/tmc.cpp
+++ b/bench/source/fib/tmc.cpp
@@ -1,0 +1,49 @@
+#include <benchmark/benchmark.h>
+
+#include "../util.hpp"
+#include "config.hpp"
+
+#include "tmc/all_headers.hpp"
+
+namespace {
+
+using namespace tmc;
+
+auto fib(int n) -> task<int> {
+  if (n < 2) {
+    co_return n;
+  }
+
+  /* Spawn one, then serially execute the other, then await the first */
+  auto xt = spawn(fib(n - 1)).run_early();
+  auto y = co_await fib(n - 2);
+  auto x = co_await xt;
+  co_return x + y;
+}
+
+void fib_tmc(benchmark::State &state) {
+
+  state.counters["green_threads"] = state.range(0);
+  state.counters["fib(n)"] = work;
+
+  volatile int secret = work;
+  volatile int output;
+
+  tmc::cpu_executor().set_thread_count(state.range(0)).init();
+
+  for (auto _ : state) {
+    output = tmc::post_waitable(tmc::cpu_executor(), fib(secret), 0).get();
+  }
+
+  tmc::cpu_executor().teardown();
+
+#ifndef LF_NO_CHECK
+  if (output != sfib(work)) {
+    std::cout << "error" << std::endl;
+  }
+#endif
+}
+
+} // namespace
+
+BENCHMARK(fib_tmc)->Apply(targs)->UseRealTime();

--- a/bench/source/integrate/tmc.cpp
+++ b/bench/source/integrate/tmc.cpp
@@ -1,0 +1,60 @@
+#include <benchmark/benchmark.h>
+
+#include "../util.hpp"
+#include "config.hpp"
+
+#include "tmc/all_headers.hpp"
+
+namespace {
+
+using namespace tmc;
+
+auto integrate(double x1, double y1, double x2, double y2, double area) -> task<double> {
+  //
+  double half = (x2 - x1) / 2;
+  double x0 = x1 + half;
+  double y0 = fn(x0);
+
+  double area_x1x0 = (y1 + y0) / 2 * half;
+  double area_x0x2 = (y0 + y2) / 2 * half;
+  double area_x1x2 = area_x1x0 + area_x0x2;
+
+  if (area_x1x2 - area < epsilon && area - area_x1x2 < epsilon) {
+    co_return area_x1x2;
+  }
+
+  auto xt = spawn(integrate(x1, y1, x0, y0, area_x1x0)).run_early();
+  auto y = co_await integrate(x0, y0, x2, y2, area_x0x2);
+  auto x = co_await xt;
+
+  co_return x + y;
+};
+
+void integrate_tmc(benchmark::State &state) {
+
+  state.counters["green_threads"] = state.range(0);
+  state.counters["integrate_n"] = n;
+  state.counters["integrate_epsilon"] = epsilon;
+
+  volatile double out;
+
+  tmc::cpu_executor().set_thread_count(state.range(0)).init();
+
+  for (auto _ : state) {
+    out = tmc::post_waitable(tmc::cpu_executor(), integrate(0, fn(0), n, fn(n), 0), 0).get();
+  }
+
+  tmc::cpu_executor().teardown();
+
+  double expect = integral_fn(0, n);
+
+  if (out - expect < epsilon && expect - out < epsilon) {
+    return;
+  }
+
+  std::cout << "error: " << out << "!=" << expect << std::endl;
+}
+
+} // namespace
+
+BENCHMARK(integrate_tmc)->Apply(targs)->UseRealTime();

--- a/bench/source/matmul/tmc.cpp
+++ b/bench/source/matmul/tmc.cpp
@@ -1,0 +1,92 @@
+#include "../util.hpp"
+#include "config.hpp"
+#include <benchmark/benchmark.h>
+
+#include "tmc/all_headers.hpp"
+
+namespace {
+
+using namespace tmc;
+
+using mat = float *;
+
+/**
+ * @brief Recursive divide-and-conquer matrix multiplication, powers of 2, only.
+ *
+ * a00 a01            =  a00 * b00 + a01 * b10,   a00 * b01 + a01 * b11
+ * a10 a11            =  a10 * b00 + a11 * b10,   a10 * b01 + a11 * b11
+ *           b00 b01
+ *           b10 b11
+ */
+auto matmul(mat A, mat B, mat R, unsigned n, unsigned s, auto add) -> task<void> {
+  //
+  if (n * sizeof(float) <= lf::impl::k_cache_line) {
+    co_return multiply(A, B, R, n, s, add);
+  }
+
+  LF_ASSERT(std::has_single_bit(n));
+  LF_ASSERT(std::has_single_bit(s));
+
+  unsigned m = n / 2;
+
+  unsigned o00 = 0;
+  unsigned o01 = m;
+  unsigned o10 = m * s;
+  unsigned o11 = m * s + m;
+
+  {
+    auto a = spawn(matmul(A + o00, B + o00, R + o00, m, s, add)).run_early();
+    auto b = spawn(matmul(A + o00, B + o01, R + o01, m, s, add)).run_early();
+    auto c = spawn(matmul(A + o10, B + o00, R + o10, m, s, add)).run_early();
+    /* */ co_await matmul(A + o10, B + o01, R + o11, m, s, add);
+
+    co_await a;
+    co_await b;
+    co_await c;
+  }
+
+  {
+    auto a = spawn(matmul(A + o01, B + o10, R + o00, m, s, std::true_type{})).run_early();
+    auto b = spawn(matmul(A + o01, B + o11, R + o01, m, s, std::true_type{})).run_early();
+    auto c = spawn(matmul(A + o11, B + o10, R + o10, m, s, std::true_type{})).run_early();
+    /* */ co_await matmul(A + o11, B + o11, R + o11, m, s, std::true_type{});
+
+    co_await a;
+    co_await b;
+    co_await c;
+  }
+};
+
+void matmul_tmc(benchmark::State &state) {
+
+  state.counters["green_threads"] = state.range(0);
+  state.counters["mat NxN"] = matmul_work;
+
+  tmc::cpu_executor().set_thread_count(state.range(0)).init();
+
+  auto [A, B, C1, C2, n] = matmul_init(matmul_work);
+
+  for (auto _ : state) {
+    tmc::post_waitable(tmc::cpu_executor(), matmul(A.get(), B.get(), C1.get(), n, n, std::false_type{}), 0)
+        .get();
+  }
+
+  tmc::cpu_executor().teardown();
+
+#ifndef LF_NO_CHECK
+  iter_matmul(A.get(), B.get(), C2.get(), n);
+
+  if (maxerror(C1.get(), C2.get(), n) > 1e-6) {
+    std::cout << "lf maxerror: " << maxerror(C1.get(), C2.get(), n) << std::endl;
+  }
+#endif
+}
+
+} // namespace
+
+using namespace lf;
+
+// BENCHMARK(matmul_libfork<unit_pool, numa_strategy::seq>)->DenseRange(1, 1)->UseRealTime();
+// BENCHMARK(matmul_libfork<debug_pool, numa_strategy::seq>)->DenseRange(1, 1)->UseRealTime();
+
+BENCHMARK(matmul_tmc)->Apply(targs)->UseRealTime();

--- a/bench/source/tmc.cpp
+++ b/bench/source/tmc.cpp
@@ -1,0 +1,3 @@
+#define TMC_IMPL
+
+#include "tmc/all_headers.hpp"

--- a/bench/source/uts/ccpp.cpp
+++ b/bench/source/uts/ccpp.cpp
@@ -1,0 +1,92 @@
+#include <algorithm>
+#include <iostream>
+#include <span>
+
+#include <benchmark/benchmark.h>
+
+// #define LF_DEFAULT_LOGGING
+
+#include "concurrencpp/concurrencpp.h"
+
+#include "../util.hpp"
+#include "config.hpp"
+#include "external/uts.h"
+
+namespace {
+
+using namespace concurrencpp;
+
+struct pair2 {
+  concurrencpp::result<::result> res;
+  Node child;
+};
+
+auto uts(executor_tag, thread_pool_executor *tpe, int depth, Node *parent) -> concurrencpp::result<::result> {
+  //
+  ::result r(depth, 1, 0);
+
+  int num_children = uts_numChildren(parent);
+  int child_type = uts_childType(parent);
+
+  parent->numChildren = num_children;
+
+  if (num_children > 0) {
+
+    std::vector<pair2> cs(num_children);
+
+    for (int i = 0; i < num_children; i++) {
+
+      cs[i].child.type = child_type;
+      cs[i].child.height = parent->height + 1;
+      cs[i].child.numChildren = -1; // not yet determined
+
+      for (int j = 0; j < computeGranularity; j++) {
+        rng_spawn(parent->state.state, cs[i].child.state.state, i);
+      }
+
+      cs[i].res = uts({}, tpe, depth + 1, &cs[i].child);
+    }
+
+    for (auto &&elem : cs) {
+
+      auto res = co_await elem.res;
+
+      r.maxdepth = max(r.maxdepth, res.maxdepth);
+      r.size += res.size;
+      r.leaves += res.leaves;
+    }
+  } else {
+    r.leaves = 1;
+  }
+  co_return r;
+};
+
+void uts_ccpp(benchmark::State &state, int tree) {
+  state.counters["green_threads"] = state.range(0);
+
+  setup_tree(tree);
+
+  volatile int depth = 0;
+  Node root;
+
+  ::result r;
+
+  concurrencpp::runtime_options opt;
+  opt.max_cpu_threads = state.range(0);
+  concurrencpp::runtime runtime(opt);
+
+  auto tpe = runtime.thread_pool_executor();
+
+  for (auto _ : state) {
+    uts_initRoot(&root, type);
+    r = uts({}, tpe.get(), depth, &root).get();
+  }
+
+  if (r != result_tree(tree)) {
+    std::cerr << "lf uts " << tree << " failed" << std::endl;
+  }
+}
+
+} // namespace
+
+MAKE_UTS_FOR(uts_ccpp);

--- a/bench/source/uts/config.hpp
+++ b/bench/source/uts/config.hpp
@@ -206,15 +206,13 @@ inline auto result_tree(int i) -> result {
     case 12:
       return {13, 102181082, 81746377};
     case 13:
-      // TODO: what is the result?
-      return {0, 0, 0};
+      return {15, 4230646601, 3384495738};
     case 31:
       return {1572, 4112897, 3599034};
     case 32:
       return {17844, 111345631, 89076904};
     case 33:
-      // TODO: what is the result?
-      return {0, 0, 0};
+      return {99049, 2793220501, 1396611250};
     default:
       assert(false && "Invalid tree id");
   }

--- a/bench/source/uts/config.hpp
+++ b/bench/source/uts/config.hpp
@@ -1,6 +1,8 @@
 #ifndef DD1EB460_E250_4A8C_B35B_C99A803E5301
 #define DD1EB460_E250_4A8C_B35B_C99A803E5301
 
+#include <exception>
+#include <iostream>
 #include <stdexcept>
 
 #include "../util.hpp"
@@ -198,31 +200,25 @@ inline void setup_tree(int i) {
 
 inline auto result_tree(int i) -> result {
 
-  return {0, 0, 0};
-
   switch (i) {
-    case 1:
+    case 11:
       return {10, 4130071, 3305118};
-    case 2:
-      return {81, 4117769, 2342762};
-    case 3:
-      return {1572, 4112897, 3599034};
-    case 4:
-      return {134, 4132453, 3108986};
-    case 5:
-      return {20, 4147582, 2181318};
-    case 6:
+    case 12:
       return {13, 102181082, 81746377};
-    case 7:
-      return {67, 96793510, 53791152};
-    case 8:
+    case 13:
+      // TODO: what is the result?
+      return {0, 0, 0};
+    case 31:
+      return {1572, 4112897, 3599034};
+    case 32:
       return {17844, 111345631, 89076904};
-    case 9:
+    case 33:
+      // TODO: what is the result?
       return {0, 0, 0};
     default:
       assert(false && "Invalid tree id");
-      break;
   }
+  std::terminate();
 }
 
 #define MAKE_UTS_FOR(some_type)                                                                              \

--- a/bench/source/uts/tmc.cpp
+++ b/bench/source/uts/tmc.cpp
@@ -1,0 +1,85 @@
+#include <algorithm>
+#include <iostream>
+#include <optional>
+#include <span>
+
+#include <benchmark/benchmark.h>
+
+#include "tmc/all_headers.hpp"
+
+#include "../util.hpp"
+#include "config.hpp"
+#include "external/uts.h"
+
+namespace {
+
+using namespace tmc;
+
+auto uts(int depth, Node *parent) -> task<result> {
+  //
+  result r(depth, 1, 0);
+
+  int num_children = uts_numChildren(parent);
+  int child_type = uts_childType(parent);
+
+  parent->numChildren = num_children;
+
+  if (num_children > 0) {
+
+    std::vector<Node> cs(num_children);
+    std::vector<task<result>> tsk(num_children);
+
+    for (int i = 0; i < num_children; i++) {
+
+      cs[i].type = child_type;
+      cs[i].height = parent->height + 1;
+      cs[i].numChildren = -1; // not yet determined
+
+      for (int j = 0; j < computeGranularity; j++) {
+        rng_spawn(parent->state.state, cs[i].state.state, i);
+      }
+
+      tsk[i] = uts(depth + 1, &cs[i]);
+    }
+
+    auto results = co_await spawn_many(tsk.data(), num_children);
+
+    for (auto &&res : results) {
+      r.maxdepth = max(r.maxdepth, res.maxdepth);
+      r.size += res.size;
+      r.leaves += res.leaves;
+    }
+  } else {
+    r.leaves = 1;
+  }
+  co_return r;
+};
+
+void uts_tmc(benchmark::State &state, int tree) {
+
+  state.counters["green_threads"] = state.range(0);
+
+  setup_tree(tree);
+
+  volatile int depth = 0;
+  Node root;
+
+  result r;
+
+  tmc::cpu_executor().set_thread_count(state.range(0)).init();
+
+  for (auto _ : state) {
+    uts_initRoot(&root, type);
+    r = tmc::post_waitable(tmc::cpu_executor(), uts(depth, &root), 0).get();
+  }
+
+  tmc::cpu_executor().teardown();
+
+  if (r != result_tree(tree)) {
+    std::cerr << "lf uts " << tree << " failed" << std::endl;
+  }
+}
+
+} // namespace
+
+MAKE_UTS_FOR(uts_tmc);


### PR DESCRIPTION
This adds UTS/fib/integrate/matmul benchmarks against [TooManyCooks](https://github.com/tzcnt/TooManyCooks) and UTS/fib benchmarks for [concurrencpp](https://github.com/David-Haim/concurrencpp) in preparation for resolving #14 