### PR TITLE
Test for hardware support for atomics, link to libatomic if not detected

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,12 +25,16 @@ message(STATUS "CMAKE_BUILD_TYPE is set to '${CMAKE_BUILD_TYPE}'")
 
 find_package(Threads REQUIRED)
 
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  include(cmake/atomic.cmake)
+endif()
+
 # ------ Declare library ------
 
 add_library(libfork_libfork INTERFACE)
 add_library(libfork::libfork ALIAS libfork_libfork)
 
-target_link_libraries(libfork_libfork INTERFACE Threads::Threads)
+target_link_libraries(libfork_libfork INTERFACE Threads::Threads ${LIBFORK_EXTRA_LIBS})
 
 set_property(TARGET libfork_libfork PROPERTY EXPORT_NAME libfork)
 

--- a/cmake/atomic.cmake
+++ b/cmake/atomic.cmake
@@ -1,0 +1,11 @@
+include(CheckCXXSourceCompiles)
+check_cxx_source_compiles("#include <atomic>
+int main() {
+  std::atomic<uint8_t> w1;
+  std::atomic<uint64_t> w8;
+  return ++w1 + ++w8;
+}" NATIVE_ATOMICS_SUPPORTED)
+
+if(NOT NATIVE_ATOMICS_SUPPORTED)
+  set(LIBFORK_EXTRA_LIBS ${LIBFORK_EXTRA_LIBS} atomic)
+endif()


### PR DESCRIPTION
@ConorWilliams Will this work? On ppc it works correctly, test fails and `-latomic` is added to linker flags:
```
/opt/local/bin/g++-mp-14 -pipe -Os -DNDEBUG -I/opt/local/include -D_GLIBCXX_USE_CXX11_ABI=0 -arch ppc -mmacosx-version-min=10.6 -Wl,-search_paths_first -Wl,-headerpad_max_install_names -L/opt/local/lib -Wl,-headerpad_max_install_names CMakeFiles/libfork_test.dir/source/algorithm/explicit.cpp.o CMakeFiles/libfork_test.dir/source/algorithm/fold.cpp.o CMakeFiles/libfork_test.dir/source/algorithm/for_each.cpp.o CMakeFiles/libfork_test.dir/source/algorithm/map.cpp.o CMakeFiles/libfork_test.dir/source/algorithm/scan.cpp.o CMakeFiles/libfork_test.dir/source/catch.cpp.o CMakeFiles/libfork_test.dir/source/core/bad_behavior.cpp.o CMakeFiles/libfork_test.dir/source/core/core.cpp.o CMakeFiles/libfork_test.dir/source/core/deque.cpp.o CMakeFiles/libfork_test.dir/source/core/eventually.cpp.o CMakeFiles/libfork_test.dir/source/core/exceptions.cpp.o CMakeFiles/libfork_test.dir/source/core/explicit.cpp.o CMakeFiles/libfork_test.dir/source/core/extern.cpp.o CMakeFiles/libfork_test.dir/source/core/extern_test.cpp.o CMakeFiles/libfork_test.dir/source/core/just.cpp.o CMakeFiles/libfork_test.dir/source/core/lazy_pool.cpp.o CMakeFiles/libfork_test.dir/source/core/result.cpp.o CMakeFiles/libfork_test.dir/source/core/unbalanced.cpp.o CMakeFiles/libfork_test.dir/source/core/wsq.cpp.o CMakeFiles/libfork_test.dir/source/macro.cpp.o CMakeFiles/libfork_test.dir/source/numa.cpp.o CMakeFiles/libfork_test.dir/source/schedule/event_count.cpp.o -o libfork_test  -Wl,-rpath,/opt/local/lib /opt/local/lib/libCatch2Main.a -latomic /opt/local/lib/libCatch2.a
```

P. S. 1-byte atomics may be needed by RISCV, so I added that too.