### PR TITLE
[V4] Fixed capacity deque

### DIFF
--- a/benchmark/src/libfork_benchmark/fib/baremetal.cpp
+++ b/benchmark/src/libfork_benchmark/fib/baremetal.cpp
@@ -139,7 +139,7 @@ void fib_recursive_deque(benchmark::State &state) {
 
   state.counters["n"] = static_cast<double>(n);
 
-  lf::deque<std::int64_t> deque;
+  lf::deque<std::int64_t> deque{64};
   tls_deque = &deque;
 
   for (auto _ : state) {

--- a/benchmark/src/libfork_benchmark/fib/lf_parts.cpp
+++ b/benchmark/src/libfork_benchmark/fib/lf_parts.cpp
@@ -78,7 +78,7 @@ struct deque_ctx {
 
   using handle_type = lf::frame_handle<deque_ctx>;
 
-  lf::deque<handle_type> work;
+  lf::deque<handle_type> work{64};
   Alloc my_allocator;
 
   auto allocator() noexcept -> Alloc & { return my_allocator; }
@@ -121,7 +121,7 @@ struct poly_deque_ctx final : lf::basic_poly_context<Alloc> {
 
   using handle_type = lf::frame_handle<lf::basic_poly_context<Alloc>>;
 
-  lf::deque<handle_type> work;
+  lf::deque<handle_type> work{64};
 
   void post(lf::await_handle<lf::basic_poly_context<Alloc>>) override {}
 

--- a/src/core/constants.cxx
+++ b/src/core/constants.cxx
@@ -10,7 +10,15 @@ constexpr std::size_t k_megabyte = 1024 * k_kilobyte;
 constexpr std::uint32_t k_u16_max = std::numeric_limits<std::uint16_t>::max();
 
 export constexpr std::size_t k_new_align = __STDCPP_DEFAULT_NEW_ALIGNMENT__;
-export constexpr std::size_t k_cache_line = std::hardware_destructive_interference_size;
 export constexpr std::size_t k_page_size = 4096; // 4 KiB on most systems.
+
+#if defined(__GNUC__) && !defined(__clang__) && !defined(__INTEL_COMPILER)
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Winterference-size"
+#endif // #ifdef __GNUC__
+export constexpr std::size_t k_cache_line = std::hardware_destructive_interference_size;
+#if defined(__GNUC__) && !defined(__clang__) && !defined(__INTEL_COMPILER)
+  #pragma GCC diagnostic pop
+#endif // #ifdef __GNUC__
 
 } // namespace lf

--- a/src/core/deque.cxx
+++ b/src/core/deque.cxx
@@ -27,7 +27,7 @@ concept dequeable = lock_free<T> && std::default_initializable<T>;
  * @brief Thrown when a push operation fails because the deque is full.
  */
 export struct deque_full : std::runtime_error {
-  constexpr deque_full() : std::runtime_error{"push faild because deque is full"} {}
+  constexpr deque_full() : std::runtime_error{"push failed because deque is full"} {}
 };
 
 /**
@@ -364,7 +364,7 @@ constexpr auto deque<T>::push(T val) -> std::ptrdiff_t {
   std::atomic_thread_fence(release);
   m_bottom.store(bottom + 1, relaxed);
 
-  // This was the size just befor the push, upon return the size could be any
+  // This was the size just before the push, upon return the size could be any
   // smaller number, down to zero, as stealers could have stolen all the
   // tasks.
   return ssize;

--- a/src/core/deque.cxx
+++ b/src/core/deque.cxx
@@ -193,9 +193,9 @@ class deque : immovable {
   /**
    * @brief Construct a new empty deque object.
    *
-   * @param cap The capacity of the deque (must be a power of two).
+   * @param cap The capacity of the deque (will be rounded to the next power of two).
    */
-  constexpr explicit deque(std::ptrdiff_t cap);
+  constexpr explicit deque(std::size_t cap);
   /**
    * @brief Get the number of elements in the deque.
    */
@@ -258,7 +258,7 @@ class deque : immovable {
 };
 
 template <dequeable T>
-constexpr deque<T>::deque(std::ptrdiff_t cap) : m_buf(cap) {}
+constexpr deque<T>::deque(std::size_t cap) : m_buf(safe_cast<std::ptrdiff_t>(std::bit_ceil(cap))) {}
 
 template <dequeable T>
 constexpr auto deque<T>::size() const noexcept -> std::size_t {

--- a/src/core/deque.cxx
+++ b/src/core/deque.cxx
@@ -321,10 +321,12 @@ deque<T>::pop(Fn &&when_empty) noexcept(std::is_nothrow_invocable_v<Fn>) -> std:
 
   std::ptrdiff_t top = m_top.load(relaxed);
 
-  // TODO: match line-for-line with the paper
-
   if (top <= bottom) {
     // Non-empty deque
+
+    // This load is not required to be atomic as we are the exclusive writer.
+    T val = m_buf.load(bottom);
+
     if (top == bottom) {
       // The last item could get stolen, by a stealer that loaded bottom before our write above.
       if (!m_top.compare_exchange_strong(top, top + 1, seq_cst, relaxed)) {
@@ -334,9 +336,7 @@ deque<T>::pop(Fn &&when_empty) noexcept(std::is_nothrow_invocable_v<Fn>) -> std:
       }
       m_bottom.store(bottom + 1, relaxed);
     }
-    // Can delay load until after acquiring slot as only this thread can push(),
-    // This load is not required to be atomic as we are the exclusive writer.
-    return m_buf.load(bottom);
+    return val;
   }
   m_bottom.store(bottom + 1, relaxed);
   return std::invoke(std::forward<Fn>(when_empty));

--- a/src/core/deque.cxx
+++ b/src/core/deque.cxx
@@ -185,6 +185,87 @@ export template <dequeable T>
 class deque : immovable {
  public:
   /**
+   * @brief A non-owning handle that can be used to steal items from the deque.
+   *
+   * All non-owner interactions with the deque should be made through this handle.
+   */
+  class thief_handle {
+
+    friend class deque;
+
+    explicit thief_handle(deque *queue) noexcept : m_queue{queue} { LF_ASSUME(queue != nullptr); }
+
+   public:
+    /**
+     * @brief Check if the deque is empty.
+     */
+    [[nodiscard]]
+    constexpr auto empty(this thief_handle self) noexcept -> bool {
+      std::ptrdiff_t const top = self.m_queue->m_top.load(acquire);
+      std::atomic_thread_fence(seq_cst);
+      std::ptrdiff_t const bottom = self.m_queue->m_bottom.load(acquire);
+      return top >= bottom;
+    }
+    /**
+     * @brief Get the number of elements in the deque.
+     */
+    [[nodiscard]]
+    constexpr auto size(this thief_handle self) noexcept -> std::size_t {
+      return static_cast<std::size_t>(self->ssize());
+    }
+    /**
+     * @brief Get the number of elements in the deque as a signed integer.
+     */
+    [[nodiscard]]
+    constexpr auto ssize(this thief_handle self) noexcept -> std::ptrdiff_t {
+      std::ptrdiff_t const top = self.m_queue->m_top.load(acquire);
+      std::atomic_thread_fence(seq_cst);
+      std::ptrdiff_t const bottom = self.m_queue->m_bottom.load(acquire);
+      return std::max(bottom - top, std::ptrdiff_t{0});
+    }
+    /**
+     * @brief Get the capacity of the deque.
+     */
+    [[nodiscard]]
+    constexpr auto capacity(this thief_handle self) noexcept -> std::ptrdiff_t {
+      return self.m_queue->capacity();
+    }
+    /**
+     * @brief Steal an item from the deque.
+     *
+     * Any threads can try to steal an item from the deque. This operation can
+     * fail if the deque is empty or if another thread simultaneously stole an
+     * item from the deque.
+     */
+    constexpr auto steal(this thief_handle self) noexcept -> steal_t<T> {
+      //
+      std::ptrdiff_t top = self.m_queue->m_top.load(acquire);
+      std::atomic_thread_fence(seq_cst);
+      std::ptrdiff_t const bottom = self.m_queue->m_bottom.load(acquire);
+
+      if (top < bottom) {
+        // Must load *before* acquiring the slot as slot may be overwritten immediately after
+        // acquiring. This load is NOT required to be atomic even-though it may race with an overwrite
+        // as we only return the value if we win the race below guaranteeing we had no race during our
+        // read. If we loose the race then 'x' could be corrupt due to read-during-write race but as T
+        // is trivially destructible this does not matter.
+        T tmp = self.m_queue->m_buf.load(top);
+
+        static_assert(std::is_trivially_destructible_v<T>, "'atomicable' should guarantee this already");
+
+        if (!self.m_queue->m_top.compare_exchange_strong(top, top + 1, seq_cst, relaxed)) {
+          return {.code = err::lost, .val = {}};
+        }
+        return {.code = err::none, .val = tmp};
+      }
+      return {.code = err::empty, .val = {}};
+    }
+
+   private:
+    deque *m_queue;
+  };
+
+  /**
    * @brief The type of the elements in the deque.
    */
   using value_type = T;
@@ -193,27 +274,39 @@ class deque : immovable {
    *
    * @param cap The capacity of the deque (will be rounded to the next power of two).
    */
-  constexpr explicit deque(std::size_t cap);
-  /**
-   * @brief Get the number of elements in the deque.
-   */
-  [[nodiscard]]
-  constexpr auto size() const noexcept -> std::size_t;
-  /**
-   * @brief Get the number of elements in the deque as a signed integer.
-   */
-  [[nodiscard]]
-  constexpr auto ssize() const noexcept -> std::ptrdiff_t;
-  /**
-   * @brief Get the capacity of the deque.
-   */
-  [[nodiscard]]
-  constexpr auto capacity() const noexcept -> std::ptrdiff_t;
+  constexpr explicit deque(std::size_t cap) : m_buf(safe_cast<std::ptrdiff_t>(std::bit_ceil(cap))) {}
   /**
    * @brief Check if the deque is empty.
    */
   [[nodiscard]]
-  constexpr auto empty() const noexcept -> bool;
+  constexpr auto empty() const noexcept -> bool {
+    std::ptrdiff_t const bottom = m_bottom.load(relaxed);
+    std::ptrdiff_t const top = m_top.load(seq_cst);
+    return top >= bottom;
+  }
+  /**
+   * @brief Get the number of elements in the deque.
+   */
+  [[nodiscard]]
+  constexpr auto size() const noexcept -> std::size_t {
+    return static_cast<std::size_t>(ssize());
+  }
+  /**
+   * @brief Get the number of elements in the deque as a signed integer.
+   */
+  [[nodiscard]]
+  constexpr auto ssize() const noexcept -> std::ptrdiff_t {
+    std::ptrdiff_t const bottom = m_bottom.load(relaxed);
+    std::ptrdiff_t const top = m_top.load(seq_cst);
+    return std::max(bottom - top, std::ptrdiff_t{0});
+  }
+  /**
+   * @brief Get the capacity of the deque.
+   */
+  [[nodiscard]]
+  constexpr auto capacity() const noexcept -> std::ptrdiff_t {
+    return m_buf.capacity();
+  }
   /**
    * @brief Push an item into the deque.
    *
@@ -236,13 +329,9 @@ class deque : immovable {
   constexpr auto
   pop(Fn &&when_empty = {}) noexcept(std::is_nothrow_invocable_v<Fn>) -> std::invoke_result_t<Fn>;
   /**
-   * @brief Steal an item from the deque.
-   *
-   * Any threads can try to steal an item from the deque. This operation can
-   * fail if the deque is empty or if another thread simultaneously stole an
-   * item from the deque.
+   * @brief Get a non-owning `thief_handle` that can be used to steal items from the deque.
    */
-  constexpr auto steal() noexcept -> steal_t<T>;
+  constexpr auto thief() noexcept -> thief_handle { return thief_handle{this}; }
 
  private:
   alignas(k_cache_line) atomic_ring_buf<T> m_buf;
@@ -256,33 +345,6 @@ class deque : immovable {
   static constexpr std::memory_order release = std::memory_order_release;
   static constexpr std::memory_order seq_cst = std::memory_order_seq_cst;
 };
-
-template <dequeable T>
-constexpr deque<T>::deque(std::size_t cap) : m_buf(safe_cast<std::ptrdiff_t>(std::bit_ceil(cap))) {}
-
-template <dequeable T>
-constexpr auto deque<T>::size() const noexcept -> std::size_t {
-  return static_cast<std::size_t>(ssize());
-}
-
-template <dequeable T>
-constexpr auto deque<T>::ssize() const noexcept -> std::ptrdiff_t {
-  std::ptrdiff_t const bottom = m_bottom.load(relaxed);
-  std::ptrdiff_t const top = m_top.load(seq_cst);
-  return std::max(bottom - top, std::ptrdiff_t{0});
-}
-
-template <dequeable T>
-constexpr auto deque<T>::capacity() const noexcept -> std::ptrdiff_t {
-  return m_buf.capacity();
-}
-
-template <dequeable T>
-constexpr auto deque<T>::empty() const noexcept -> bool {
-  std::ptrdiff_t const bottom = m_bottom.load(relaxed);
-  std::ptrdiff_t const top = m_top.load(seq_cst);
-  return top >= bottom;
-}
 
 template <dequeable T>
 constexpr auto deque<T>::push(T val) -> std::ptrdiff_t {
@@ -340,30 +402,6 @@ deque<T>::pop(Fn &&when_empty) noexcept(std::is_nothrow_invocable_v<Fn>) -> std:
   }
   m_bottom.store(bottom + 1, relaxed);
   return std::invoke(std::forward<Fn>(when_empty));
-}
-
-template <dequeable T>
-constexpr auto deque<T>::steal() noexcept -> steal_t<T> {
-  std::ptrdiff_t top = m_top.load(acquire);
-  std::atomic_thread_fence(seq_cst);
-  std::ptrdiff_t const bottom = m_bottom.load(acquire);
-
-  if (top < bottom) {
-    // Must load *before* acquiring the slot as slot may be overwritten immediately after
-    // acquiring. This load is NOT required to be atomic even-though it may race with an overwrite
-    // as we only return the value if we win the race below guaranteeing we had no race during our
-    // read. If we loose the race then 'x' could be corrupt due to read-during-write race but as T
-    // is trivially destructible this does not matter.
-    T tmp = m_buf.load(top);
-
-    static_assert(std::is_trivially_destructible_v<T>, "concept 'atomicable' should guarantee this already");
-
-    if (!m_top.compare_exchange_strong(top, top + 1, seq_cst, relaxed)) {
-      return {.code = err::lost, .val = {}};
-    }
-    return {.code = err::none, .val = tmp};
-  }
-  return {.code = err::empty, .val = {}};
 }
 
 } // namespace lf

--- a/src/core/deque.cxx
+++ b/src/core/deque.cxx
@@ -24,6 +24,13 @@ export template <typename T>
 concept dequeable = lock_free<T> && std::default_initializable<T>;
 
 /**
+ * @brief Thrown when a push operation fails because the deque is full.
+ */
+export struct deque_full : std::runtime_error {
+  constexpr deque_full() : std::runtime_error{"push faild because deque is full"} {}
+};
+
+/**
  * @brief A basic wrapper around a c-style array that provides modulo load/stores.
  *
  * This class is designed for internal use only. It provides a c-style API that is
@@ -39,10 +46,9 @@ struct atomic_ring_buf {
    * @param cap The capacity of the buffer, MUST be a power of 2.
    */
   constexpr explicit atomic_ring_buf(std::ptrdiff_t cap)
-      : m_buf{std::make_unique_for_overwrite<std::atomic<T>[]>(safe_cast<std::size_t>(m_cap))},
+      : m_buf{std::make_unique_for_overwrite<std::atomic<T>[]>(safe_cast<std::size_t>(cap))},
         m_cap{cap},
-        m_mask{cap - 1},
-  {
+        m_mask{cap - 1} {
     LF_ASSUME(cap > 0 && std::has_single_bit(safe_cast<std::size_t>(cap)));
   }
   /**
@@ -172,16 +178,13 @@ struct return_nullopt {
  *
  * Also see:
 
- * - https://github.com/crossbeam-rs/crossbeam/blob/master/crossbeam-deque/src/deque.rs
+ * - Rust: https://github.com/crossbeam-rs/crossbeam/blob/master/crossbeam-deque/src/deque.rs
+ * - CDSC: https://dl.acm.org/doi/epdf/10.1145/2544173.2509514
  *
  * @tparam T The type of the elements in the deque.
  */
 export template <dequeable T>
 class deque : immovable {
-
-  static constexpr std::ptrdiff_t k_default_capacity = 1024;
-  static constexpr std::size_t k_garbage_reserve = 64;
-
  public:
   /**
    * @brief The type of the elements in the deque.
@@ -189,12 +192,8 @@ class deque : immovable {
   using value_type = T;
   /**
    * @brief Construct a new empty deque object.
-   */
-  constexpr deque() : deque(k_default_capacity) {}
-  /**
-   * @brief Construct a new empty deque object.
    *
-   * @param cap The capacity of the deque (must be a power of 2).
+   * @param cap The capacity of the deque (must be a power of two).
    */
   constexpr explicit deque(std::ptrdiff_t cap);
   /**
@@ -221,8 +220,7 @@ class deque : immovable {
    * @brief Push an item into the deque.
    *
    * Only the owner thread can insert an item into the deque.
-   * This operation can trigger the deque to resize if more space is required.
-   * This may throw if an allocation is required and then fails.
+   * This will throw an exception if the deque is full.
    * This returns the number of elements in the deque before the push.
    *
    * @param val Value to add to the deque.
@@ -238,28 +236,18 @@ class deque : immovable {
     requires std::convertible_to<T, std::invoke_result_t<Fn>>
   constexpr auto
   pop(Fn &&when_empty = {}) noexcept(std::is_nothrow_invocable_v<Fn>) -> std::invoke_result_t<Fn>;
-
   /**
    * @brief Steal an item from the deque.
    *
    * Any threads can try to steal an item from the deque. This operation can fail if the deque is
    * empty or if another thread simultaneously stole an item from the deque.
    */
-  [[nodiscard]]
   constexpr auto steal() noexcept -> steal_t<T>;
 
-  /**
-   * @brief Destroy the deque object.
-   *
-   * All threads must have finished using the deque before it is destructed.
-   */
-  constexpr ~deque() noexcept;
-
  private:
-  alignas(k_cache_line) std::atomic<std::ptrdiff_t> m_top;
-  alignas(k_cache_line) std::atomic<std::ptrdiff_t> m_bottom;
-  alignas(k_cache_line) std::atomic<atomic_ring_buf<T> *> m_buf;
-  std::vector<std::unique_ptr<atomic_ring_buf<T>>> m_garbage;
+  alignas(k_cache_line) atomic_ring_buf<T> m_buf;
+  alignas(k_cache_line) std::atomic<std::ptrdiff_t> m_top{0};
+  alignas(k_cache_line) std::atomic<std::ptrdiff_t> m_bottom{0};
 
   // Convenience aliases.
   static constexpr std::memory_order relaxed = std::memory_order_relaxed;
@@ -270,11 +258,7 @@ class deque : immovable {
 };
 
 template <dequeable T>
-constexpr deque<T>::deque(std::ptrdiff_t cap) : m_top(0),
-                                                m_bottom(0),
-                                                m_buf(new atomic_ring_buf<T>{cap}) {
-  m_garbage.reserve(k_garbage_reserve);
-}
+constexpr deque<T>::deque(std::ptrdiff_t cap) : m_buf(cap) {}
 
 template <dequeable T>
 constexpr auto deque<T>::size() const noexcept -> std::size_t {
@@ -290,7 +274,7 @@ constexpr auto deque<T>::ssize() const noexcept -> std::ptrdiff_t {
 
 template <dequeable T>
 constexpr auto deque<T>::capacity() const noexcept -> std::ptrdiff_t {
-  return m_buf.load(relaxed)->capacity();
+  return m_buf.capacity();
 }
 
 template <dequeable T>
@@ -304,25 +288,15 @@ template <dequeable T>
 constexpr auto deque<T>::push(T val) -> std::ptrdiff_t {
   std::ptrdiff_t const bottom = m_bottom.load(relaxed);
   std::ptrdiff_t const top = m_top.load(acquire);
-  atomic_ring_buf<T> *buf = m_buf.load(relaxed);
-
   std::ptrdiff_t const ssize = bottom - top;
 
-  if (buf->capacity() < ssize + 1) {
-    // Deque is full, build a new one.
-    atomic_ring_buf<T> *bigger = buf->resize(bottom, top);
-
-    [&]() noexcept -> void {
-      // This should never throw as we reserve 64 slots.
-      m_garbage.emplace_back(std::exchange(buf, bigger));
-    }();
-
-    m_buf.store(buf, relaxed);
+  if (m_buf.capacity() < ssize + 1) {
+    LF_THROW(deque_full{});
   }
 
   // Construct new object, this does not have to be atomic as no one can steal this item until
   // after we store the new value of bottom, ordering is maintained by surrounding atomics.
-  buf->store(bottom, val);
+  m_buf.store(bottom, val);
 
   std::atomic_thread_fence(release);
   m_bottom.store(bottom + 1, relaxed);
@@ -336,7 +310,6 @@ constexpr auto
 deque<T>::pop(Fn &&when_empty) noexcept(std::is_nothrow_invocable_v<Fn>) -> std::invoke_result_t<Fn> {
 
   std::ptrdiff_t const bottom = m_bottom.load(relaxed) - 1; //
-  atomic_ring_buf<T> *buf = m_buf.load(relaxed);            //
   m_bottom.store(bottom, relaxed);                          // Stealers can no longer steal.
 
   std::atomic_thread_fence(seq_cst);
@@ -358,13 +331,13 @@ deque<T>::pop(Fn &&when_empty) noexcept(std::is_nothrow_invocable_v<Fn>) -> std:
     }
     // Can delay load until after acquiring slot as only this thread can push(),
     // This load is not required to be atomic as we are the exclusive writer.
-    return buf->load(bottom);
+    return m_buf.load(bottom);
   }
   m_bottom.store(bottom + 1, relaxed);
   return std::invoke(std::forward<Fn>(when_empty));
 }
 
-// READ: https://dl.acm.org/doi/epdf/10.1145/2544173.2509514
+// TODO: READ: https://dl.acm.org/doi/epdf/10.1145/2544173.2509514
 
 template <dequeable T>
 constexpr auto deque<T>::steal() noexcept -> steal_t<T> {
@@ -378,7 +351,7 @@ constexpr auto deque<T>::steal() noexcept -> steal_t<T> {
     // as we only return the value if we win the race below guaranteeing we had no race during our
     // read. If we loose the race then 'x' could be corrupt due to read-during-write race but as T
     // is trivially destructible this does not matter.
-    T tmp = m_buf.load(consume)->load(top);
+    T tmp = m_buf.load(top);
 
     static_assert(std::is_trivially_destructible_v<T>, "concept 'atomicable' should guarantee this already");
 
@@ -388,11 +361,6 @@ constexpr auto deque<T>::steal() noexcept -> steal_t<T> {
     return {.code = err::none, .val = tmp};
   }
   return {.code = err::empty, .val = {}};
-}
-
-template <dequeable T>
-constexpr deque<T>::~deque() noexcept {
-  delete m_buf.load(); // NOLINT
 }
 
 } // namespace lf

--- a/src/core/deque.cxx
+++ b/src/core/deque.cxx
@@ -211,7 +211,7 @@ class deque : immovable {
      */
     [[nodiscard]]
     constexpr auto size(this thief_handle self) noexcept -> std::size_t {
-      return static_cast<std::size_t>(self->ssize());
+      return static_cast<std::size_t>(self.ssize());
     }
     /**
      * @brief Get the number of elements in the deque as a signed integer.

--- a/src/core/deque.cxx
+++ b/src/core/deque.cxx
@@ -38,9 +38,12 @@ struct atomic_ring_buf {
    *
    * @param cap The capacity of the buffer, MUST be a power of 2.
    */
-  constexpr explicit atomic_ring_buf(std::ptrdiff_t cap) : m_cap{cap}, m_mask{cap - 1} {
-    LF_ASSUME(cap > 0);
-    LF_ASSUME(std::has_single_bit(static_cast<std::size_t>(cap)));
+  constexpr explicit atomic_ring_buf(std::ptrdiff_t cap)
+      : m_buf{std::make_unique_for_overwrite<std::atomic<T>[]>(safe_cast<std::size_t>(m_cap))},
+        m_cap{cap},
+        m_mask{cap - 1},
+  {
+    LF_ASSUME(cap > 0 && std::has_single_bit(safe_cast<std::size_t>(cap)));
   }
   /**
    * @brief Get the capacity of the buffer.
@@ -64,32 +67,12 @@ struct atomic_ring_buf {
     LF_ASSUME(index >= 0);
     return (m_buf.get() + (index & m_mask))->load(std::memory_order_relaxed); // NOLINT Avoid cast.
   }
-  /**
-   * @brief Copies elements in range ``[bottom, top)`` into a new ring buffer.
-   *
-   * This function allocates a new buffer and returns a pointer to it.
-   * The caller is responsible for deallocating the memory.
-   *
-   * @param bot The bottom of the range to copy from (inclusive).
-   * @param top The top of the range to copy from (exclusive).
-   */
-  [[nodiscard]]
-  constexpr auto resize(std::ptrdiff_t bot, std::ptrdiff_t top) const -> atomic_ring_buf<T> * {
-
-    auto *ptr = new atomic_ring_buf{2 * m_cap}; // NOLINT
-
-    for (std::ptrdiff_t i = top; i != bot; ++i) {
-      ptr->store(i, load(i));
-    }
-
-    return ptr;
-  }
 
  private:
   /**
    * @brief An array of atomic elements.
    */
-  using array_t = std::atomic<T>[]; // NOLINT
+  std::unique_ptr<std::atomic<T>[]> m_buf;
   /**
    * @brief Capacity of the buffer.
    */
@@ -98,12 +81,6 @@ struct atomic_ring_buf {
    * @brief Bit mask to perform modulo capacity operations.
    */
   std::ptrdiff_t m_mask;
-
-#ifdef __cpp_lib_smart_ptr_for_overwrite
-  std::unique_ptr<array_t> m_buf = std::make_unique_for_overwrite<array_t>(static_cast<std::size_t>(m_cap));
-#else
-  std::unique_ptr<array_t> m_buf = std::make_unique<array_t>(static_cast<std::size_t>(m_cap));
-#endif
 };
 
 /**

--- a/src/core/deque.cxx
+++ b/src/core/deque.cxx
@@ -217,9 +217,9 @@ class deque : immovable {
   /**
    * @brief Push an item into the deque.
    *
-   * Only the owner thread can insert an item into the deque.
-   * This will throw an exception if the deque is full.
-   * This returns the number of elements in the deque before the push.
+   * Only the owner thread can insert an item into the deque. This will throw
+   * an exception if the deque is full. This returns the number of elements in
+   * the deque before the push.
    *
    * @param val Value to add to the deque.
    */
@@ -227,8 +227,9 @@ class deque : immovable {
   /**
    * @brief Pop an item from the deque.
    *
-   * Only the owner thread can pop out an item from the deque. If the buffer is empty calls `when_empty` and
-   * returns the result. By default, `when_empty` is a no-op that returns a null `std::optional<T>`.
+   * Only the owner thread can pop out an item from the deque. If the buffer is
+   * empty calls `when_empty` and returns the result. By default, `when_empty`
+   * is a no-op that returns a null `std::optional<T>`.
    */
   template <std::invocable Fn = return_nullopt<T>>
     requires std::convertible_to<T, std::invoke_result_t<Fn>>
@@ -237,8 +238,9 @@ class deque : immovable {
   /**
    * @brief Steal an item from the deque.
    *
-   * Any threads can try to steal an item from the deque. This operation can fail if the deque is
-   * empty or if another thread simultaneously stole an item from the deque.
+   * Any threads can try to steal an item from the deque. This operation can
+   * fail if the deque is empty or if another thread simultaneously stole an
+   * item from the deque.
    */
   constexpr auto steal() noexcept -> steal_t<T>;
 
@@ -292,12 +294,17 @@ constexpr auto deque<T>::push(T val) -> std::ptrdiff_t {
     LF_THROW(deque_full{});
   }
 
-  // Construct new object, this does not have to be atomic as no one can steal this item until
-  // after we store the new value of bottom, ordering is maintained by surrounding atomics.
+  // Construct new object, this does not have to be atomic as no one can steal
+  // this item until after we store the new value of bottom, ordering is
+  // maintained by surrounding atomics.
   m_buf.store(bottom, val);
 
   std::atomic_thread_fence(release);
   m_bottom.store(bottom + 1, relaxed);
+
+  // This was the size just befor the push, upon return the size could be any
+  // smaller number, down to zero, as stealers could have stolen all the
+  // tasks.
   return ssize;
 }
 

--- a/src/core/deque.cxx
+++ b/src/core/deque.cxx
@@ -163,8 +163,6 @@ struct return_nullopt {
   static constexpr auto operator()() noexcept -> std::optional<T> { return {}; }
 };
 
-// TODO: drop relaxed semantics on buffer load/store, look at crossbeam
-
 /**
  * @brief A bounded lock-free single-producer multiple-consumer work-stealing deque.
  *
@@ -268,7 +266,7 @@ constexpr auto deque<T>::size() const noexcept -> std::size_t {
 template <dequeable T>
 constexpr auto deque<T>::ssize() const noexcept -> std::ptrdiff_t {
   std::ptrdiff_t const bottom = m_bottom.load(relaxed);
-  std::ptrdiff_t const top = m_top.load(relaxed);
+  std::ptrdiff_t const top = m_top.load(seq_cst);
   return std::max(bottom - top, std::ptrdiff_t{0});
 }
 
@@ -280,7 +278,7 @@ constexpr auto deque<T>::capacity() const noexcept -> std::ptrdiff_t {
 template <dequeable T>
 constexpr auto deque<T>::empty() const noexcept -> bool {
   std::ptrdiff_t const bottom = m_bottom.load(relaxed);
-  std::ptrdiff_t const top = m_top.load(relaxed);
+  std::ptrdiff_t const top = m_top.load(seq_cst);
   return top >= bottom;
 }
 

--- a/src/core/deque.cxx
+++ b/src/core/deque.cxx
@@ -337,8 +337,6 @@ deque<T>::pop(Fn &&when_empty) noexcept(std::is_nothrow_invocable_v<Fn>) -> std:
   return std::invoke(std::forward<Fn>(when_empty));
 }
 
-// TODO: READ: https://dl.acm.org/doi/epdf/10.1145/2544173.2509514
-
 template <dequeable T>
 constexpr auto deque<T>::steal() noexcept -> steal_t<T> {
   std::ptrdiff_t top = m_top.load(acquire);

--- a/src/core/deque.cxx
+++ b/src/core/deque.cxx
@@ -157,11 +157,10 @@ struct return_nullopt {
   static constexpr auto operator()() noexcept -> std::optional<T> { return {}; }
 };
 
-// TODO: drop relaxed semantics on buffer load/store:
-// https://github.com/crossbeam-rs/crossbeam/blob/master/crossbeam-deque/src/deque.rs
+// TODO: drop relaxed semantics on buffer load/store, look at crossbeam
 
 /**
- * @brief An unbounded lock-free single-producer multiple-consumer work-stealing deque.
+ * @brief A bounded lock-free single-producer multiple-consumer work-stealing deque.
  *
  * Implements the "Chase-Lev" deque described in the papers, `"Dynamic Circular Work-Stealing deque"
  * <https://doi.org/10.1145/1073970.1073974>`_ and `"Correct and Efficient Work-Stealing for Weak
@@ -170,6 +169,10 @@ struct return_nullopt {
  * Only the deque owner can perform ``pop()`` and ``push()`` operations where the deque behaves
  * like a LIFO stack. Others can (only) ``steal()`` data from the deque, they see a FIFO deque.
  * All threads must have finished using the deque before it is destructed.
+ *
+ * Also see:
+
+ * - https://github.com/crossbeam-rs/crossbeam/blob/master/crossbeam-deque/src/deque.rs
  *
  * @tparam T The type of the elements in the deque.
  */

--- a/src/core/stack.cxx
+++ b/src/core/stack.cxx
@@ -25,7 +25,7 @@ export class geometric_stack {
 
   // Align such that the entire node is on a cache line
   struct alignas(std::max(std::bit_ceil(sizeof(node_data)), alignof(node_data))) node : node_data {
-    constexpr node(node *prev, std::size_t size) : node_data{.prev = prev, .size = size} {
+    constexpr node(node *prev_arg, std::size_t size_arg) : node_data{.prev = prev_arg, .size = size_arg} {
       // Each stacklet should be on a boundary.
       LF_ASSUME(is_aligned<k_new_align>(stacklet.get()));
     }

--- a/src/core/utility.cxx
+++ b/src/core/utility.cxx
@@ -133,7 +133,7 @@ constexpr auto is_aligned(void *ptr) noexcept -> bool {
 }
 
 /**
- * @brief Round up size to a multiple of `k_new_align` for alignment purposes.
+ * @brief Round up size to a multiple of `Align` for alignment purposes.
  */
 export template <std::size_t Align>
   requires (std::has_single_bit(Align))

--- a/test/src/deque.cpp
+++ b/test/src/deque.cpp
@@ -81,7 +81,7 @@ void test_deque(std::size_t n_pushes, std::size_t n_consumers, bool do_pop) {
       start.arrive_and_wait();
 
       for (;;) {
-        auto [err, item] = deque.steal();
+        auto [err, item] = deque.thief().steal();
 
         switch (err) {
           case lf::err::none:

--- a/test/src/deque.cpp
+++ b/test/src/deque.cpp
@@ -13,7 +13,8 @@ TEST_CASE("Deque: Concepts", "[deque]") {
 }
 
 TEST_CASE("Deque: Single thread as stack", "[deque]") {
-  lf::deque<int> deque;
+  // Only need a few
+  lf::deque<int> deque{16};
 
   REQUIRE(deque.empty());
 
@@ -33,7 +34,7 @@ TEST_CASE("Deque: Single thread as stack", "[deque]") {
 }
 
 TEST_CASE("Deque: Custom pop when_empty", "[deque]") {
-  lf::deque<int> deque;
+  lf::deque<int> deque{2};
 
   auto result = deque.pop([]() {
     return -1;
@@ -57,7 +58,7 @@ namespace {
 void test_deque(std::size_t n_pushes, std::size_t n_consumers, bool do_pop) {
 
   // The tested queue
-  lf::deque<std::uint64_t> deque{};
+  lf::deque<std::uint64_t> deque{n_pushes};
 
   // To store removed elements
   std::vector<std::uint64_t> pops{};
@@ -206,18 +207,4 @@ TEST_CASE("Deque: MPSC with-pop", "[deque]") {
       DYNAMIC_SECTION("Elements: " << i << " Consumers: " << j) { test_deque(i, j, true); }
     }
   }
-}
-
-TEST_CASE("Deque: Capacity Growth", "[deque]") {
-  lf::deque<int> d(2);
-  REQUIRE(d.capacity() == 2);
-  d.push(1);
-  d.push(2);
-  REQUIRE(d.capacity() == 2);
-  d.push(3); // Should trigger resize
-  REQUIRE(d.capacity() > 2);
-  REQUIRE(d.ssize() == 3);
-  REQUIRE(*d.pop() == 3);
-  REQUIRE(*d.pop() == 2);
-  REQUIRE(*d.pop() == 1);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deque now throws `deque_full` exception when capacity is exceeded.
  * Introduced `thief_handle` for safe concurrent work-stealing operations.

* **Breaking Changes**
  * Deque constructor now requires explicit capacity parameter (no default constructor).
  * `deque::steal()` method replaced with `deque::thief().steal()` pattern.

* **Chores**
  * Updated benchmarks for new deque initialization API.
  * Compiler diagnostic improvements for cache-line constant handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->