### PR TITLE
[V4] Scheduling split 1/n

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,7 @@ target_sources(libfork_libfork
       # Context
       src/context/context.cxx
       src/context/dummy.cxx
+      src/context/inline.cxx
     PRIVATE
       src/exception.cpp
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ target_sources(libfork_libfork
       src/core/tuple.cxx
       src/core/ops.cxx
       src/core/poly_context.cxx
+      src/core/generic_context.cxx
       src/core/thread_locals.cxx
       src/core/deque.cxx
       src/core/schedule.cxx
@@ -75,7 +76,6 @@ target_sources(libfork_libfork
       # Schedule
       src/schedule/schedule.cxx
       src/schedule/dummy.cxx
-      src/schedule/inline.cxx
     PRIVATE
       src/exception.cpp
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,10 +72,10 @@ target_sources(libfork_libfork
       src/core/handles.cxx
       src/core/stacks/geometric.cxx
       src/core/stacks/dummy.cxx
-      # Context
-      src/context/context.cxx
-      src/context/dummy.cxx
-      src/context/inline.cxx
+      # Schedule
+      src/schedule/schedule.cxx
+      src/schedule/dummy.cxx
+      src/schedule/inline.cxx
     PRIVATE
       src/exception.cpp
 )

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -54,6 +54,7 @@ target_sources(libfork_benchmark
 target_sources(libfork_benchmark
   PRIVATE
     src/libfork_benchmark/fib/lf_parts.cpp
+    src/libfork_benchmark/fib/libfork.cpp
 )
 
 target_link_libraries(libfork_benchmark

--- a/benchmark/src/libfork_benchmark/fib/baremetal.cpp
+++ b/benchmark/src/libfork_benchmark/fib/baremetal.cpp
@@ -132,6 +132,8 @@ auto fib_recursive_deque_impl(std::int64_t n) -> std::int64_t {
   return a + b;
 }
 
+// TODO: can we generalize the runner function?
+
 void fib_recursive_deque(benchmark::State &state) {
 
   std::int64_t n = state.range(0);

--- a/benchmark/src/libfork_benchmark/fib/fib.hpp
+++ b/benchmark/src/libfork_benchmark/fib/fib.hpp
@@ -10,7 +10,7 @@
 #include "libfork_benchmark/common.hpp"
 
 import libfork.core;
-import libfork.context;
+import libfork.schedule;
 
 inline constexpr int fib_test = 3;
 inline constexpr int fib_base = 37;

--- a/benchmark/src/libfork_benchmark/fib/fib.hpp
+++ b/benchmark/src/libfork_benchmark/fib/fib.hpp
@@ -10,6 +10,7 @@
 #include "libfork_benchmark/common.hpp"
 
 import libfork.core;
+import libfork.context;
 
 inline constexpr int fib_test = 3;
 inline constexpr int fib_base = 37;

--- a/benchmark/src/libfork_benchmark/fib/lf_parts.cpp
+++ b/benchmark/src/libfork_benchmark/fib/lf_parts.cpp
@@ -55,7 +55,7 @@ static_assert(lf::stack_allocator<linear_allocator>);
 template <lf::stack_allocator Alloc>
 struct vector_ctx {
 
-  using handle_type = lf::frame_handle<vector_ctx>;
+  using handle_type = lf::steal_handle<vector_ctx>;
 
   std::vector<handle_type> work;
   Alloc my_allocator;
@@ -85,7 +85,7 @@ struct vector_ctx {
 template <lf::stack_allocator Alloc>
 struct deque_ctx {
 
-  using handle_type = lf::frame_handle<deque_ctx>;
+  using handle_type = lf::steal_handle<deque_ctx>;
 
   lf::deque<handle_type> work{64};
   Alloc my_allocator;
@@ -107,7 +107,7 @@ struct deque_ctx {
 template <lf::stack_allocator Alloc>
 struct poly_vector_ctx final : lf::basic_poly_context<Alloc> {
 
-  using handle_type = lf::frame_handle<lf::basic_poly_context<Alloc>>;
+  using handle_type = lf::steal_handle<lf::basic_poly_context<Alloc>>;
 
   std::vector<handle_type> work;
 
@@ -132,7 +132,7 @@ struct poly_vector_ctx final : lf::basic_poly_context<Alloc> {
 template <lf::stack_allocator Alloc>
 struct poly_deque_ctx final : lf::basic_poly_context<Alloc> {
 
-  using handle_type = lf::frame_handle<lf::basic_poly_context<Alloc>>;
+  using handle_type = lf::steal_handle<lf::basic_poly_context<Alloc>>;
 
   lf::deque<handle_type> work{64};
 

--- a/benchmark/src/libfork_benchmark/fib/lf_parts.cpp
+++ b/benchmark/src/libfork_benchmark/fib/lf_parts.cpp
@@ -62,7 +62,7 @@ struct vector_ctx {
 
   vector_ctx() { work.reserve(1024); }
 
-  auto allocator() noexcept -> Stack & { return my_allocator; }
+  auto stack() noexcept -> Stack & { return my_allocator; }
 
   void post(lf::sched_handle<vector_ctx>) {}
 
@@ -90,7 +90,7 @@ struct deque_ctx {
   lf::deque<handle_type> work{64};
   Stack my_allocator;
 
-  auto allocator() noexcept -> Stack & { return my_allocator; }
+  auto stack() noexcept -> Stack & { return my_allocator; }
 
   void post(lf::sched_handle<deque_ctx>) {}
 

--- a/benchmark/src/libfork_benchmark/fib/lf_parts.cpp
+++ b/benchmark/src/libfork_benchmark/fib/lf_parts.cpp
@@ -207,7 +207,7 @@ constexpr auto fork_call = [](this auto fib, std::int64_t n) -> lf::task<std::in
 
 using global_alloc = vector_ctx<global_allocator>;
 using linear_alloc = vector_ctx<linear_allocator>;
-using stacks_alloc = vector_ctx<lf::stack::geometric<>>;
+using stacks_alloc = vector_ctx<lf::stacks::geometric<>>;
 
 template <auto Fn, typename T, typename U = T>
 void fib(benchmark::State &state) {
@@ -289,8 +289,8 @@ using B = lf::basic_poly_context<linear_allocator>;
 BENCHMARK(fib<fork_call<B>, A, B>)->Name("test/libfork/fib/poly_vector_ctx")->Arg(fib_test);
 BENCHMARK(fib<fork_call<B>, A, B>)->Name("base/libfork/fib/poly_vector_ctx")->Arg(fib_base);
 
-using E = poly_vector_ctx<lf::stack::geometric<>>;
-using F = lf::basic_poly_context<lf::stack::geometric<>>;
+using E = poly_vector_ctx<lf::stacks::geometric<>>;
+using F = lf::basic_poly_context<lf::stacks::geometric<>>;
 
 BENCHMARK(fib<fork_call<F>, E, F>)->Name("test/libfork/fib/poly_geometric_vector_ctx")->Arg(fib_test);
 BENCHMARK(fib<fork_call<F>, E, F>)->Name("base/libfork/fib/poly_geometric_vector_ctx")->Arg(fib_base);
@@ -323,8 +323,8 @@ BENCHMARK(fib<fork_call<F, true>, E, F>)
 
 using C = poly_deque_ctx<linear_allocator>;
 using D = deque_ctx<linear_allocator>;
-using G = deque_ctx<lf::stack::geometric<>>;
-using H = poly_deque_ctx<lf::stack::geometric<>>;
+using G = deque_ctx<lf::stacks::geometric<>>;
+using H = poly_deque_ctx<lf::stacks::geometric<>>;
 
 // Return by value,
 // Libfork call/join/fork with co-await,

--- a/benchmark/src/libfork_benchmark/fib/lf_parts.cpp
+++ b/benchmark/src/libfork_benchmark/fib/lf_parts.cpp
@@ -64,7 +64,7 @@ struct vector_ctx {
 
   auto allocator() noexcept -> Alloc & { return my_allocator; }
 
-  void post(lf::await_handle<vector_ctx>) {}
+  void post(lf::sched_handle<vector_ctx>) {}
 
   // TODO: try LF_NO_INLINE for final allocator
   LF_NO_INLINE
@@ -92,7 +92,7 @@ struct deque_ctx {
 
   auto allocator() noexcept -> Alloc & { return my_allocator; }
 
-  void post(lf::await_handle<deque_ctx>) {}
+  void post(lf::sched_handle<deque_ctx>) {}
 
   // TODO: try LF_NO_INLINE for final allocator
   void push(handle_type handle) { work.push(handle); }
@@ -113,7 +113,7 @@ struct poly_vector_ctx final : lf::basic_poly_context<Alloc> {
 
   poly_vector_ctx() { work.reserve(1024); }
 
-  void post(lf::await_handle<lf::basic_poly_context<Alloc>>) override {}
+  void post(lf::sched_handle<lf::basic_poly_context<Alloc>>) override {}
 
   void push(handle_type handle) override { work.push_back(handle); }
 
@@ -136,7 +136,7 @@ struct poly_deque_ctx final : lf::basic_poly_context<Alloc> {
 
   lf::deque<handle_type> work{64};
 
-  void post(lf::await_handle<lf::basic_poly_context<Alloc>>) override {}
+  void post(lf::sched_handle<lf::basic_poly_context<Alloc>>) override {}
 
   void push(handle_type handle) override { work.push(handle); }
 

--- a/benchmark/src/libfork_benchmark/fib/lf_parts.cpp
+++ b/benchmark/src/libfork_benchmark/fib/lf_parts.cpp
@@ -28,7 +28,7 @@ struct global_allocator {
   constexpr static auto acquire(empty) noexcept -> void {}
 };
 
-static_assert(lf::stack_allocator<global_allocator>);
+static_assert(lf::worker_stack<global_allocator>);
 
 struct linear_allocator {
 
@@ -50,9 +50,9 @@ struct linear_allocator {
   constexpr auto acquire(std::byte *) noexcept -> void {}
 };
 
-static_assert(lf::stack_allocator<linear_allocator>);
+static_assert(lf::worker_stack<linear_allocator>);
 
-template <lf::stack_allocator Alloc>
+template <lf::worker_stack Alloc>
 struct vector_ctx {
 
   using handle_type = lf::steal_handle<vector_ctx>;
@@ -82,7 +82,7 @@ struct vector_ctx {
   }
 };
 
-template <lf::stack_allocator Alloc>
+template <lf::worker_stack Alloc>
 struct deque_ctx {
 
   using handle_type = lf::steal_handle<deque_ctx>;
@@ -104,7 +104,7 @@ struct deque_ctx {
   }
 };
 
-template <lf::stack_allocator Alloc>
+template <lf::worker_stack Alloc>
 struct poly_vector_ctx final : lf::basic_poly_context<Alloc> {
 
   using handle_type = lf::steal_handle<lf::basic_poly_context<Alloc>>;
@@ -129,7 +129,7 @@ struct poly_vector_ctx final : lf::basic_poly_context<Alloc> {
   }
 };
 
-template <lf::stack_allocator Alloc>
+template <lf::worker_stack Alloc>
 struct poly_deque_ctx final : lf::basic_poly_context<Alloc> {
 
   using handle_type = lf::steal_handle<lf::basic_poly_context<Alloc>>;

--- a/benchmark/src/libfork_benchmark/fib/lf_parts.cpp
+++ b/benchmark/src/libfork_benchmark/fib/lf_parts.cpp
@@ -52,17 +52,17 @@ struct linear_allocator {
 
 static_assert(lf::worker_stack<linear_allocator>);
 
-template <lf::worker_stack Alloc>
+template <lf::worker_stack Stack>
 struct vector_ctx {
 
   using handle_type = lf::steal_handle<vector_ctx>;
 
   std::vector<handle_type> work;
-  Alloc my_allocator;
+  Stack my_allocator;
 
   vector_ctx() { work.reserve(1024); }
 
-  auto allocator() noexcept -> Alloc & { return my_allocator; }
+  auto allocator() noexcept -> Stack & { return my_allocator; }
 
   void post(lf::sched_handle<vector_ctx>) {}
 
@@ -82,15 +82,15 @@ struct vector_ctx {
   }
 };
 
-template <lf::worker_stack Alloc>
+template <lf::worker_stack Stack>
 struct deque_ctx {
 
   using handle_type = lf::steal_handle<deque_ctx>;
 
   lf::deque<handle_type> work{64};
-  Alloc my_allocator;
+  Stack my_allocator;
 
-  auto allocator() noexcept -> Alloc & { return my_allocator; }
+  auto allocator() noexcept -> Stack & { return my_allocator; }
 
   void post(lf::sched_handle<deque_ctx>) {}
 
@@ -104,16 +104,16 @@ struct deque_ctx {
   }
 };
 
-template <lf::worker_stack Alloc>
-struct poly_vector_ctx final : lf::basic_poly_context<Alloc> {
+template <lf::worker_stack Stack>
+struct poly_vector_ctx final : lf::basic_poly_context<Stack> {
 
-  using handle_type = lf::steal_handle<lf::basic_poly_context<Alloc>>;
+  using handle_type = lf::steal_handle<lf::basic_poly_context<Stack>>;
 
   std::vector<handle_type> work;
 
   poly_vector_ctx() { work.reserve(1024); }
 
-  void post(lf::sched_handle<lf::basic_poly_context<Alloc>>) override {}
+  void post(lf::sched_handle<lf::basic_poly_context<Stack>>) override {}
 
   void push(handle_type handle) override { work.push_back(handle); }
 
@@ -129,14 +129,14 @@ struct poly_vector_ctx final : lf::basic_poly_context<Alloc> {
   }
 };
 
-template <lf::worker_stack Alloc>
-struct poly_deque_ctx final : lf::basic_poly_context<Alloc> {
+template <lf::worker_stack Stack>
+struct poly_deque_ctx final : lf::basic_poly_context<Stack> {
 
-  using handle_type = lf::steal_handle<lf::basic_poly_context<Alloc>>;
+  using handle_type = lf::steal_handle<lf::basic_poly_context<Stack>>;
 
   lf::deque<handle_type> work{64};
 
-  void post(lf::sched_handle<lf::basic_poly_context<Alloc>>) override {}
+  void post(lf::sched_handle<lf::basic_poly_context<Stack>>) override {}
 
   void push(handle_type handle) override { work.push(handle); }
 

--- a/benchmark/src/libfork_benchmark/fib/libfork.cpp
+++ b/benchmark/src/libfork_benchmark/fib/libfork.cpp
@@ -57,7 +57,7 @@ void run(benchmark::State &state) {
 
 using lf::inline_context;
 using lf::deque;
-using lf::stack::geometric;
+using lf::stacks::geometric;
 
 // // Minimal coroutine, bump allocated (thread-local) stack
 // BENCHMARK_TEMPLATE(run, inline_context<false, geometric<>>)->Name("test/libfork/inline/nopoly/geometric")->Arg(fib_test);

--- a/benchmark/src/libfork_benchmark/fib/libfork.cpp
+++ b/benchmark/src/libfork_benchmark/fib/libfork.cpp
@@ -59,7 +59,7 @@ using lf::inline_context;
 using lf::deque;
 using lf::stack::geometric;
 
-// Minimal coroutine, bump allocated (thread-local) stack
-BENCHMARK_TEMPLATE(run, inline_context<false, geometric<>>)->Name("test/libfork/inline/nopoly/geometric")->Arg(fib_test);
-BENCHMARK_TEMPLATE(run, inline_context<false, geometric<>>)->Name("base/libfork/inline/nopoly/geometric")->Arg(fib_base);
+// // Minimal coroutine, bump allocated (thread-local) stack
+// BENCHMARK_TEMPLATE(run, inline_context<false, geometric<>>)->Name("test/libfork/inline/nopoly/geometric")->Arg(fib_test);
+// BENCHMARK_TEMPLATE(run, inline_context<false, geometric<>>)->Name("base/libfork/inline/nopoly/geometric")->Arg(fib_base);
 

--- a/benchmark/src/libfork_benchmark/fib/libfork.cpp
+++ b/benchmark/src/libfork_benchmark/fib/libfork.cpp
@@ -61,5 +61,5 @@ using lf::stack::geometric;
 
 // Minimal coroutine, bump allocated (thread-local) stack
 BENCHMARK_TEMPLATE(run, inline_context<false, geometric<>>)->Name("test/libfork/inline/nopoly/geometric")->Arg(fib_test);
-// BENCHMARK_TEMPLATE()->Name("base/baremetal/fib/coro")->Arg(fib_base);
+BENCHMARK_TEMPLATE(run, inline_context<false, geometric<>>)->Name("base/libfork/inline/nopoly/geometric")->Arg(fib_base);
 

--- a/benchmark/src/libfork_benchmark/fib/libfork.cpp
+++ b/benchmark/src/libfork_benchmark/fib/libfork.cpp
@@ -56,7 +56,7 @@ void run(benchmark::State &state) {
 } // namespace
 
 using lf::deque;
-using lf::inline_context;
+// using lf::inline_context;
 using lf::stacks::geometric;
 
 // // Minimal coroutine, bump allocated (thread-local) stack

--- a/benchmark/src/libfork_benchmark/fib/libfork.cpp
+++ b/benchmark/src/libfork_benchmark/fib/libfork.cpp
@@ -1,0 +1,65 @@
+#include <coroutine>
+#include <cstddef>
+#include <exception>
+#include <memory>
+
+#include <benchmark/benchmark.h>
+
+#include "libfork_benchmark/fib/fib.hpp"
+
+// === Coroutine
+
+namespace  {
+
+using lf::env;
+using lf::task;
+using lf::worker_context;
+
+constexpr auto fib = []<worker_context Context>(this auto fib, env<Context>, std::int64_t n) -> task<std::int64_t, Context> {
+
+  if (n < 2) {
+    co_return n;
+  }
+
+  std::int64_t lhs = 0;
+  std::int64_t rhs = 0;
+
+  using scope = lf::scope<Context>;
+
+  co_await scope::fork(&rhs, fib, n - 2);
+  co_await scope::call(&lhs, fib, n - 1);
+
+  co_await lf::join();
+
+  co_return lhs + rhs;
+};
+
+template <worker_context Context>
+void run(benchmark::State &state) {
+
+  std::int64_t n = state.range(0);
+  std::int64_t expect = fib_ref(n);
+
+  state.counters["n"] = static_cast<double>(n);
+
+  Context context;
+
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(n);
+    std::int64_t return_value = 0;
+    lf::schedule(&context, fib, n);
+    CHECK_RESULT(return_value, expect);
+    benchmark::DoNotOptimize(return_value);
+  }
+}
+
+}
+
+using lf::inline_context;
+using lf::deque;
+using lf::stack::geometric;
+
+// Minimal coroutine, bump allocated (thread-local) stack
+BENCHMARK_TEMPLATE(run, inline_context<false, geometric<>>)->Name("test/libfork/inline/nopoly/geometric")->Arg(fib_test);
+// BENCHMARK_TEMPLATE()->Name("base/baremetal/fib/coro")->Arg(fib_base);
+

--- a/benchmark/src/libfork_benchmark/fib/libfork.cpp
+++ b/benchmark/src/libfork_benchmark/fib/libfork.cpp
@@ -9,14 +9,14 @@
 
 // === Coroutine
 
-namespace  {
+namespace {
 
 using lf::env;
 using lf::task;
 using lf::worker_context;
 
-constexpr auto fib = []<worker_context Context>(this auto fib, env<Context>, std::int64_t n) -> task<std::int64_t, Context> {
-
+constexpr auto fib = []<worker_context Context>(this auto fib, env<Context>,
+                                                std::int64_t n) -> task<std::int64_t, Context> {
   if (n < 2) {
     co_return n;
   }
@@ -53,13 +53,13 @@ void run(benchmark::State &state) {
   }
 }
 
-}
+} // namespace
 
-using lf::inline_context;
 using lf::deque;
+using lf::inline_context;
 using lf::stacks::geometric;
 
 // // Minimal coroutine, bump allocated (thread-local) stack
-// BENCHMARK_TEMPLATE(run, inline_context<false, geometric<>>)->Name("test/libfork/inline/nopoly/geometric")->Arg(fib_test);
-// BENCHMARK_TEMPLATE(run, inline_context<false, geometric<>>)->Name("base/libfork/inline/nopoly/geometric")->Arg(fib_base);
-
+// BENCHMARK_TEMPLATE(run, inline_context<false,
+// geometric<>>)->Name("test/libfork/inline/nopoly/geometric")->Arg(fib_test); BENCHMARK_TEMPLATE(run,
+// inline_context<false, geometric<>>)->Name("base/libfork/inline/nopoly/geometric")->Arg(fib_base);

--- a/src/context/context.cxx
+++ b/src/context/context.cxx
@@ -1,3 +1,4 @@
 export module libfork.context;
 
 export import :dummy_context;
+export import :inline_context;

--- a/src/context/dummy.cxx
+++ b/src/context/dummy.cxx
@@ -12,7 +12,7 @@ namespace lf {
 // TODO: replace dummy_allocator with fixed-allocator
 
 export struct dummy_context {
-  void post(lf::await_handle<dummy_context>);
+  void post(lf::sched_handle<dummy_context>);
   void push(lf::frame_handle<dummy_context>);
   auto pop() noexcept -> lf::frame_handle<dummy_context>;
   auto allocator() noexcept -> dummy_allocator &;

--- a/src/context/dummy.cxx
+++ b/src/context/dummy.cxx
@@ -15,7 +15,7 @@ export struct dummy_context {
   void post(lf::sched_handle<dummy_context>);
   void push(lf::steal_handle<dummy_context>);
   auto pop() noexcept -> lf::steal_handle<dummy_context>;
-  auto stack() noexcept -> dummy_allocator &;
+  auto stack() noexcept -> stacks::dummy_allocator &;
 };
 
 } // namespace lf

--- a/src/context/dummy.cxx
+++ b/src/context/dummy.cxx
@@ -13,8 +13,8 @@ namespace lf {
 
 export struct dummy_context {
   void post(lf::sched_handle<dummy_context>);
-  void push(lf::frame_handle<dummy_context>);
-  auto pop() noexcept -> lf::frame_handle<dummy_context>;
+  void push(lf::steal_handle<dummy_context>);
+  auto pop() noexcept -> lf::steal_handle<dummy_context>;
   auto allocator() noexcept -> dummy_allocator &;
 };
 

--- a/src/context/dummy.cxx
+++ b/src/context/dummy.cxx
@@ -15,7 +15,7 @@ export struct dummy_context {
   void post(lf::sched_handle<dummy_context>);
   void push(lf::steal_handle<dummy_context>);
   auto pop() noexcept -> lf::steal_handle<dummy_context>;
-  auto allocator() noexcept -> dummy_allocator &;
+  auto stack() noexcept -> dummy_allocator &;
 };
 
 } // namespace lf

--- a/src/context/inline.cxx
+++ b/src/context/inline.cxx
@@ -7,25 +7,65 @@ import libfork.core;
 
 namespace lf {
 
-export template <stack_allocator Stack>
-class inline_context {
-  using allocator_type = Stack::allocator_type;
-  using allocator_traits = std::allocator_traits<allocator_type>;
-  using allocator_handle = allocator_traits::template rebind_alloc<frame_handle<inline_context>>;
+template <typename T, typename Allocator>
+class vector_stack {
 
  public:
-  constexpr void post(await_handle<inline_context>) {}
+  constexpr void push(T value) { m_vector.push_back(value); }
 
-  constexpr void push(frame_handle<inline_context>) {}
-
-  constexpr auto pop() noexcept -> frame_handle<inline_context>;
-
-  constexpr auto allocator() noexcept -> inline_context &;
-
-  explicit constexpr inline_context(allocator_type const &) noexcept;
+  constexpr auto pop() noexcept -> T {
+    if (!m_vector.empty()) {
+      T value = m_vector.back();
+      m_vector.pop_back();
+      return value;
+    }
+    return {};
+  }
 
  private:
-  Stack m_allocator;
+  std::vector<T, Allocator> m_vector;
+};
+
+export template <                                                  //
+    bool Polymorphic,                                              //
+    stack_allocator Stack,                                         //
+    template <typename, typename> typename Container = std::vector //
+    >
+class inline_context final : public context_base<Polymorphic, Stack> {
+
+  using context_type = std::conditional_t<Polymorphic, context_base<Polymorphic, Stack>, inline_context>;
+
+  using await_h = await_handle<context_type>;
+  using frame_h = frame_handle<context_type>;
+
+  using allocator_type = Stack::allocator_type;
+  using allocator_traits = std::allocator_traits<allocator_type>;
+  using allocator_handle = allocator_traits::template rebind_alloc<frame_h>;
+
+ public:
+  constexpr void post(await_h frame) noexcept(!Polymorphic) {
+    LF_ASSERT(frame);
+
+    //
+  }
+
+  constexpr void push(frame_h frame) { m_stack.push_back(frame); }
+
+  constexpr auto pop() noexcept -> frame_h {
+    if (!m_stack.empty()) {
+      frame_h frame = m_stack.back();
+      m_stack.pop_back();
+      return frame;
+    }
+    return {};
+  }
+
+  // TODO: make allocator aware
+  // TODO: make generic over vector/deque
+
+  // explicit constexpr inline_context(allocator_type const &) noexcept;
+
+ private:
   std::vector<frame_handle<inline_context>, allocator_handle> m_stack;
 };
 

--- a/src/context/inline.cxx
+++ b/src/context/inline.cxx
@@ -35,7 +35,7 @@ class inline_context final : public context_base<Polymorphic, Stack> {
 
   using context_type = std::conditional_t<Polymorphic, context_base<Polymorphic, Stack>, inline_context>;
 
-  using await_h = await_handle<context_type>;
+  using await_h = sched_handle<context_type>;
   using frame_h = frame_handle<context_type>;
 
   using allocator_type = Stack::allocator_type;

--- a/src/context/inline.cxx
+++ b/src/context/inline.cxx
@@ -43,7 +43,7 @@ class inline_context final : public context_base<Polymorphic, Stack> {
   using allocator_handle = allocator_traits::template rebind_alloc<frame_h>;
 
  public:
-  constexpr auto poly() noexcept -> context_base<Polymorphic, Stack> *
+  constexpr auto poly() noexcept -> context_base<Polymorphic, Stack> &
     requires Polymorphic
   {
     return this;

--- a/src/context/inline.cxx
+++ b/src/context/inline.cxx
@@ -36,7 +36,7 @@ class inline_context final : public context_base<Polymorphic, Stack> {
   using context_type = std::conditional_t<Polymorphic, context_base<Polymorphic, Stack>, inline_context>;
 
   using await_h = sched_handle<context_type>;
-  using frame_h = frame_handle<context_type>;
+  using frame_h = steal_handle<context_type>;
 
   using allocator_type = Stack::allocator_type;
   using allocator_traits = std::allocator_traits<allocator_type>;
@@ -72,7 +72,7 @@ class inline_context final : public context_base<Polymorphic, Stack> {
   // explicit constexpr inline_context(allocator_type const &) noexcept;
 
  private:
-  Container<frame_handle<inline_context>, allocator_handle> m_stack;
+  Container<steal_handle<inline_context>, allocator_handle> m_stack;
 };
 
 } // namespace lf

--- a/src/context/inline.cxx
+++ b/src/context/inline.cxx
@@ -43,6 +43,12 @@ class inline_context final : public context_base<Polymorphic, Stack> {
   using allocator_handle = allocator_traits::template rebind_alloc<frame_h>;
 
  public:
+  constexpr auto poly() noexcept -> context_base<Polymorphic, Stack> *
+    requires Polymorphic
+  {
+    return this;
+  }
+
   constexpr void post(await_h frame) noexcept(!Polymorphic) {
     LF_ASSERT(frame);
 
@@ -66,7 +72,7 @@ class inline_context final : public context_base<Polymorphic, Stack> {
   // explicit constexpr inline_context(allocator_type const &) noexcept;
 
  private:
-  std::vector<frame_handle<inline_context>, allocator_handle> m_stack;
+  Container<frame_handle<inline_context>, allocator_handle> m_stack;
 };
 
 } // namespace lf

--- a/src/context/inline.cxx
+++ b/src/context/inline.cxx
@@ -1,0 +1,32 @@
+module;
+export module libfork.context:inline_context;
+
+import std;
+
+import libfork.core;
+
+namespace lf {
+
+export template <stack_allocator Stack>
+class inline_context {
+  using allocator_type = Stack::allocator_type;
+  using allocator_traits = std::allocator_traits<allocator_type>;
+  using allocator_handle = allocator_traits::template rebind_alloc<frame_handle<inline_context>>;
+
+ public:
+  constexpr void post(await_handle<inline_context>) {}
+
+  constexpr void push(frame_handle<inline_context>) {}
+
+  constexpr auto pop() noexcept -> frame_handle<inline_context>;
+
+  constexpr auto allocator() noexcept -> inline_context &;
+
+  explicit constexpr inline_context(allocator_type const &) noexcept;
+
+ private:
+  Stack m_allocator;
+  std::vector<frame_handle<inline_context>, allocator_handle> m_stack;
+};
+
+} // namespace lf

--- a/src/context/inline.cxx
+++ b/src/context/inline.cxx
@@ -28,7 +28,7 @@ class vector_stack {
 
 export template <                                                  //
     bool Polymorphic,                                              //
-    worker_stack Stack,                                         //
+    worker_stack Stack,                                            //
     template <typename, typename> typename Container = std::vector //
     >
 class inline_context final : public context_base<Polymorphic, Stack> {

--- a/src/context/inline.cxx
+++ b/src/context/inline.cxx
@@ -28,7 +28,7 @@ class vector_stack {
 
 export template <                                                  //
     bool Polymorphic,                                              //
-    stack_allocator Stack,                                         //
+    worker_stack Stack,                                         //
     template <typename, typename> typename Container = std::vector //
     >
 class inline_context final : public context_base<Polymorphic, Stack> {

--- a/src/core/concepts.cxx
+++ b/src/core/concepts.cxx
@@ -109,7 +109,7 @@ consteval auto constify(T &&x) noexcept -> std::add_const_t<T> &;
  * Slow-path operations: release, acquire
  */
 export template <typename T>
-concept stack_allocator = plain_object<T> && requires (T allocator, std::size_t n, void *ptr) {
+concept worker_stack = plain_object<T> && requires (T allocator, std::size_t n, void *ptr) {
   { allocator.push(n) } -> std::same_as<void *>;
   { allocator.pop(ptr, n) } noexcept -> std::same_as<void>;
   { allocator.checkpoint() } noexcept -> std::regular;
@@ -121,7 +121,7 @@ concept stack_allocator = plain_object<T> && requires (T allocator, std::size_t 
 /**
  * @brief Fetch the checkpoint type of a stack allocator `T`.
  */
-export template <stack_allocator T>
+export template <worker_stack T>
 using checkpoint_t = decltype(std::declval<T &>().checkpoint());
 
 // ==== Context
@@ -133,7 +133,7 @@ export template <typename T>
 struct sched_handle;
 
 template <typename T>
-concept ref_to_stack_allocator = std::is_lvalue_reference_v<T> && stack_allocator<std::remove_reference_t<T>>;
+concept ref_to_worker_stack = std::is_lvalue_reference_v<T> && worker_stack<std::remove_reference_t<T>>;
 
 /**
  * @brief Defines the API for a libfork compatible worker context.
@@ -141,7 +141,7 @@ concept ref_to_stack_allocator = std::is_lvalue_reference_v<T> && stack_allocato
  * This requires that `T` is an object type and supports the following operations:
  *
  * - Push/pop a frame handle onto the context in a LIFO manner.
- * - Have a `stack_allocator` that can be accessed via `allocator()`.
+ * - Have a `worker_stack` that can be accessed via `allocator()`.
  * - Post an await handle to the context via `post()` and promise to call resume.
  */
 export template <typename T>
@@ -150,7 +150,7 @@ concept worker_context =
       { context.post(await) } -> std::same_as<void>;
       { context.push(frame) } -> std::same_as<void>;
       { context.pop() } noexcept -> std::same_as<steal_handle<T>>;
-      { context.allocator() } noexcept -> ref_to_stack_allocator;
+      { context.allocator() } noexcept -> ref_to_worker_stack;
     };
 
 /**

--- a/src/core/concepts.cxx
+++ b/src/core/concepts.cxx
@@ -109,13 +109,13 @@ consteval auto constify(T &&x) noexcept -> std::add_const_t<T> &;
  * Slow-path operations: release, acquire
  */
 export template <typename T>
-concept worker_stack = plain_object<T> && requires (T allocator, std::size_t n, void *ptr) {
-  { allocator.push(n) } -> std::same_as<void *>;
-  { allocator.pop(ptr, n) } noexcept -> std::same_as<void>;
-  { allocator.checkpoint() } noexcept -> std::regular;
-  { allocator.prepare_release() } noexcept -> std::movable;
-  { allocator.release(allocator.prepare_release()) } noexcept -> std::same_as<void>;
-  { allocator.acquire(constify(allocator.checkpoint())) } noexcept -> std::same_as<void>;
+concept worker_stack = plain_object<T> && requires (T stack, std::size_t n, void *ptr) {
+  { stack.push(n) } -> std::same_as<void *>;
+  { stack.pop(ptr, n) } noexcept -> std::same_as<void>;
+  { stack.checkpoint() } noexcept -> std::regular;
+  { stack.prepare_release() } noexcept -> std::movable;
+  { stack.release(stack.prepare_release()) } noexcept -> std::same_as<void>;
+  { stack.acquire(constify(stack.checkpoint())) } noexcept -> std::same_as<void>;
 };
 
 /**

--- a/src/core/concepts.cxx
+++ b/src/core/concepts.cxx
@@ -147,7 +147,6 @@ concept ref_to_worker_stack = std::is_lvalue_reference_v<T> && worker_stack<std:
 export template <typename T>
 concept worker_context =
     plain_object<T> && requires (T context, steal_handle<T> frame, sched_handle<T> await) {
-      { context.post(await) } -> std::same_as<void>;
       { context.push(frame) } -> std::same_as<void>;
       { context.pop() } noexcept -> std::same_as<steal_handle<T>>;
       { context.stack() } noexcept -> ref_to_worker_stack;

--- a/src/core/concepts.cxx
+++ b/src/core/concepts.cxx
@@ -75,6 +75,8 @@ concept allocator_of = simple_allocator<T> && std::same_as<typename T::value_typ
 
 // ==== Stack
 
+// TODO: enforce plain_object
+
 template <typename T>
   requires std::is_object_v<T>
 consteval auto constify(T &&x) noexcept -> std::add_const_t<T> &;

--- a/src/core/concepts.cxx
+++ b/src/core/concepts.cxx
@@ -159,6 +159,21 @@ concept worker_context =
 export template <worker_context T>
 using stack_t = std::remove_reference_t<decltype(std::declval<T &>().stack())>;
 
+// ==== Scheduler
+
+/**
+ * @brief An object capable of scheduling a libfork task for execution.
+ *
+ * These are typed to a context, the `post` method must:
+ *
+ * - Satisfy the strong exception guarantee.
+ * - Guarantee eventual execution of the task associated with `handle`.
+ */
+export template <typename T>
+concept scheduler = requires (T sched, sched_handle<typename std::remove_cvref_t<T>::context_type> handle) {
+  { sched.post(handle) } -> std::same_as<void>;
+};
+
 // ==== Forward-decl
 
 export template <worker_context>

--- a/src/core/concepts.cxx
+++ b/src/core/concepts.cxx
@@ -83,7 +83,7 @@ template <typename T>
 consteval auto constify(T &&x) noexcept -> std::add_const_t<T> &;
 
 /**
- * @brief Defines the API for a libfork compatible stack allocator.
+ * @brief Defines the API for a libfork compatible stack.
  *
  * // TODO: define if release is required before acquire?
  *
@@ -119,7 +119,7 @@ concept worker_stack = plain_object<T> && requires (T stack, std::size_t n, void
 };
 
 /**
- * @brief Fetch the checkpoint type of a stack allocator `T`.
+ * @brief Fetch the checkpoint type of a stack `T`.
  */
 export template <worker_stack T>
 using checkpoint_t = decltype(std::declval<T &>().checkpoint());
@@ -141,7 +141,7 @@ concept ref_to_worker_stack = std::is_lvalue_reference_v<T> && worker_stack<std:
  * This requires that `T` is an object type and supports the following operations:
  *
  * - Push/pop a frame handle onto the context in a LIFO manner.
- * - Have a `worker_stack` that can be accessed via `allocator()`.
+ * - Have a `worker_stack` that can be accessed via `stack()`.
  * - Post an await handle to the context via `post()` and promise to call resume.
  */
 export template <typename T>
@@ -150,14 +150,14 @@ concept worker_context =
       { context.post(await) } -> std::same_as<void>;
       { context.push(frame) } -> std::same_as<void>;
       { context.pop() } noexcept -> std::same_as<steal_handle<T>>;
-      { context.allocator() } noexcept -> ref_to_worker_stack;
+      { context.stack() } noexcept -> ref_to_worker_stack;
     };
 
 /**
- * @brief Fetch the allocator type of a worker context `T`.
+ * @brief Fetch the stack type of a worker context `T`.
  */
 export template <worker_context T>
-using allocator_t = std::remove_reference_t<decltype(std::declval<T &>().allocator())>;
+using stack_t = std::remove_reference_t<decltype(std::declval<T &>().stack())>;
 
 // ==== Forward-decl
 

--- a/src/core/concepts.cxx
+++ b/src/core/concepts.cxx
@@ -129,7 +129,7 @@ export template <typename T>
 struct frame_handle;
 
 export template <typename T>
-struct await_handle;
+struct sched_handle;
 
 template <typename T>
 concept ref_to_stack_allocator = std::is_lvalue_reference_v<T> && stack_allocator<std::remove_reference_t<T>>;
@@ -145,7 +145,7 @@ concept ref_to_stack_allocator = std::is_lvalue_reference_v<T> && stack_allocato
  */
 export template <typename T>
 concept worker_context =
-    std::is_object_v<T> && requires (T context, frame_handle<T> frame, await_handle<T> await) {
+    std::is_object_v<T> && requires (T context, frame_handle<T> frame, sched_handle<T> await) {
       { context.post(await) } -> std::same_as<void>;
       { context.push(frame) } -> std::same_as<void>;
       { context.pop() } noexcept -> std::same_as<frame_handle<T>>;

--- a/src/core/concepts.cxx
+++ b/src/core/concepts.cxx
@@ -127,7 +127,7 @@ using checkpoint_t = decltype(std::declval<T &>().checkpoint());
 // ==== Context
 
 export template <typename T>
-struct frame_handle;
+struct steal_handle;
 
 export template <typename T>
 struct sched_handle;
@@ -146,10 +146,10 @@ concept ref_to_stack_allocator = std::is_lvalue_reference_v<T> && stack_allocato
  */
 export template <typename T>
 concept worker_context =
-    plain_object<T> && requires (T context, frame_handle<T> frame, sched_handle<T> await) {
+    plain_object<T> && requires (T context, steal_handle<T> frame, sched_handle<T> await) {
       { context.post(await) } -> std::same_as<void>;
       { context.push(frame) } -> std::same_as<void>;
-      { context.pop() } noexcept -> std::same_as<frame_handle<T>>;
+      { context.pop() } noexcept -> std::same_as<steal_handle<T>>;
       { context.allocator() } noexcept -> ref_to_stack_allocator;
     };
 

--- a/src/core/concepts.cxx
+++ b/src/core/concepts.cxx
@@ -10,18 +10,21 @@ namespace lf {
 
 // =========== Atomic related concepts =========== //
 
+template <typename T>
+concept plain_object = std::is_object_v<T> && std::same_as<T, std::remove_reference_t<T>>;
+
 /**
  * @brief Verify a type is suitable for use with `std::atomic`
  *
  * This requires a `TriviallyCopyable` type satisfying both `CopyConstructible` and `CopyAssignable`.
  */
 export template <typename T>
-concept atomicable = std::is_trivially_copyable_v<T> &&    //
-                     std::is_copy_constructible_v<T> &&    //
-                     std::is_move_constructible_v<T> &&    //
-                     std::is_copy_assignable_v<T> &&       //
-                     std::is_move_assignable_v<T> &&       //
-                     std::same_as<T, std::remove_cv_t<T>>; //
+concept atomicable = plain_object<T> &&                 //
+                     std::is_trivially_copyable_v<T> && //
+                     std::is_copy_constructible_v<T> && //
+                     std::is_move_constructible_v<T> && //
+                     std::is_copy_assignable_v<T> &&    //
+                     std::is_move_assignable_v<T>;      //
 
 /**
  * @brief A concept that verifies a type is lock-free when used with `std::atomic`.
@@ -51,7 +54,7 @@ concept specialization_of = is_specialization_of<std::remove_cvref_t<T>, Templat
  * This requires that `T` is `void` or a `std::movable` type.
  */
 export template <typename T>
-concept returnable = std::is_void_v<T> || std::movable<T>;
+concept returnable = std::is_void_v<T> || (plain_object<T> && std::movable<T>);
 
 // ==== Allocators
 
@@ -74,8 +77,6 @@ template <class T, typename U>
 concept allocator_of = simple_allocator<T> && std::same_as<typename T::value_type, U>;
 
 // ==== Stack
-
-// TODO: enforce plain_object
 
 template <typename T>
   requires std::is_object_v<T>
@@ -108,7 +109,7 @@ consteval auto constify(T &&x) noexcept -> std::add_const_t<T> &;
  * Slow-path operations: release, acquire
  */
 export template <typename T>
-concept stack_allocator = std::is_object_v<T> && requires (T allocator, std::size_t n, void *ptr) {
+concept stack_allocator = plain_object<T> && requires (T allocator, std::size_t n, void *ptr) {
   { allocator.push(n) } -> std::same_as<void *>;
   { allocator.pop(ptr, n) } noexcept -> std::same_as<void>;
   { allocator.checkpoint() } noexcept -> std::regular;
@@ -145,7 +146,7 @@ concept ref_to_stack_allocator = std::is_lvalue_reference_v<T> && stack_allocato
  */
 export template <typename T>
 concept worker_context =
-    std::is_object_v<T> && requires (T context, frame_handle<T> frame, sched_handle<T> await) {
+    plain_object<T> && requires (T context, frame_handle<T> frame, sched_handle<T> await) {
       { context.post(await) } -> std::same_as<void>;
       { context.push(frame) } -> std::same_as<void>;
       { context.pop() } noexcept -> std::same_as<frame_handle<T>>;

--- a/src/core/generic_context.cxx
+++ b/src/core/generic_context.cxx
@@ -39,12 +39,13 @@ class inline_context final : context_base<Polymorphic, Stack> {
   using context_type = std::conditional_t<Polymorphic, base_type, inline_context>;
 
  private:
-  using await_h = sched_handle<context_type>;
-  using frame_h = steal_handle<context_type>;
+  using sched_h = sched_handle<context_type>;
+  using steal_h = steal_handle<context_type>;
 
   using allocator_type = Stack::allocator_type;
   using allocator_traits = std::allocator_traits<allocator_type>;
-  using allocator_handle = allocator_traits::template rebind_alloc<frame_h>;
+
+  using container_type = Container<steal_h, typename allocator_traits::template rebind_alloc<steal_h>>;
 
  public:
   /**
@@ -54,21 +55,18 @@ class inline_context final : context_base<Polymorphic, Stack> {
 
   using base_type::stack;
 
-  constexpr void push(frame_h frame) { m_container.push_back(frame); }
+  constexpr void push(steal_h frame) { m_container.push_back(frame); }
 
-  constexpr auto pop() noexcept -> frame_h {
+  constexpr auto pop() noexcept -> steal_h {
     if (!m_container.empty()) {
-      frame_h frame = m_container.back();
+      steal_h frame = m_container.back();
       m_container.pop_back();
       return frame;
     }
     return {};
   }
 
-  constexpr void post(await_h frame) noexcept(!Polymorphic) {
-    LF_ASSERT(frame);
-    //
-  }
+  constexpr void post(sched_h frame) {}
 
   // TODO: make allocator aware
   // TODO: make generic over vector/deque
@@ -76,7 +74,7 @@ class inline_context final : context_base<Polymorphic, Stack> {
   // explicit constexpr inline_context(allocator_type const &) noexcept;
 
  private:
-  Container<steal_handle<inline_context>, allocator_handle> m_container;
+  container_type m_container;
 };
 
 } // namespace lf

--- a/src/core/generic_context.cxx
+++ b/src/core/generic_context.cxx
@@ -51,7 +51,7 @@ class inline_context final : context_base<Polymorphic, Stack> {
   /**
    * @brief Get a view of this object as a context.
    */
-  constexpr auto context() noexcept -> base_type & { return this; }
+  constexpr auto context() noexcept -> base_type & { return *this; }
 
   using base_type::stack;
 

--- a/src/core/generic_context.cxx
+++ b/src/core/generic_context.cxx
@@ -66,7 +66,7 @@ class inline_context final : context_base<Polymorphic, Stack> {
     return {};
   }
 
-  constexpr void post(sched_h frame) {}
+  // constexpr void post(sched_h frame) {}
 
   // TODO: make allocator aware
   // TODO: make generic over vector/deque

--- a/src/core/generic_context.cxx
+++ b/src/core/generic_context.cxx
@@ -1,9 +1,9 @@
-module;
-export module libfork.schedule:inline_context;
+export module libfork.core:generic_context;
 
 import std;
 
-import libfork.core;
+import :concepts;
+import :poly_context;
 
 namespace lf {
 
@@ -31,10 +31,14 @@ export template <                                                  //
     worker_stack Stack,                                            //
     template <typename, typename> typename Container = std::vector //
     >
-class inline_context final : public context_base<Polymorphic, Stack> {
+class inline_context final : context_base<Polymorphic, Stack> {
 
-  using context_type = std::conditional_t<Polymorphic, context_base<Polymorphic, Stack>, inline_context>;
+  using base_type = context_base<Polymorphic, Stack>;
 
+ public:
+  using context_type = std::conditional_t<Polymorphic, base_type, inline_context>;
+
+ private:
   using await_h = sched_handle<context_type>;
   using frame_h = steal_handle<context_type>;
 
@@ -43,27 +47,27 @@ class inline_context final : public context_base<Polymorphic, Stack> {
   using allocator_handle = allocator_traits::template rebind_alloc<frame_h>;
 
  public:
-  constexpr auto poly() noexcept -> context_base<Polymorphic, Stack> &
-    requires Polymorphic
-  {
-    return this;
+  /**
+   * @brief Get a view of this object as a context.
+   */
+  constexpr auto context() noexcept -> base_type & { return this; }
+
+  using base_type::stack;
+
+  constexpr void push(frame_h frame) { m_container.push_back(frame); }
+
+  constexpr auto pop() noexcept -> frame_h {
+    if (!m_container.empty()) {
+      frame_h frame = m_container.back();
+      m_container.pop_back();
+      return frame;
+    }
+    return {};
   }
 
   constexpr void post(await_h frame) noexcept(!Polymorphic) {
     LF_ASSERT(frame);
-
     //
-  }
-
-  constexpr void push(frame_h frame) { m_stack.push_back(frame); }
-
-  constexpr auto pop() noexcept -> frame_h {
-    if (!m_stack.empty()) {
-      frame_h frame = m_stack.back();
-      m_stack.pop_back();
-      return frame;
-    }
-    return {};
   }
 
   // TODO: make allocator aware
@@ -72,7 +76,7 @@ class inline_context final : public context_base<Polymorphic, Stack> {
   // explicit constexpr inline_context(allocator_type const &) noexcept;
 
  private:
-  Container<steal_handle<inline_context>, allocator_handle> m_stack;
+  Container<steal_handle<inline_context>, allocator_handle> m_container;
 };
 
 } // namespace lf

--- a/src/core/handles.cxx
+++ b/src/core/handles.cxx
@@ -47,7 +47,7 @@ class handle {
  * @tparam T The (potentially incomplete) worker context.
  */
 export template <typename T>
-struct frame_handle : handle<T> {
+struct steal_handle : handle<T> {
   using handle<T>::handle;
 };
 

--- a/src/core/handles.cxx
+++ b/src/core/handles.cxx
@@ -58,11 +58,11 @@ struct frame_handle : handle<T> {
 // maximum determined by uint16_max
 
 export template <typename T>
-struct await_handle : handle<T> {
+struct sched_handle : handle<T> {
 
   using handle<T>::handle;
 
-  constexpr auto resume_on(this await_handle self, T *context) noexcept -> void {
+  constexpr auto resume_on(this sched_handle self, T *context) noexcept -> void {
     LF_ASSUME(context == get_context<T>());
     // get(key(), self);
 

--- a/src/core/poly_context.cxx
+++ b/src/core/poly_context.cxx
@@ -6,29 +6,29 @@ import :concepts;
 
 namespace lf {
 
-export template <worker_stack Alloc>
+export template <worker_stack Stack>
 class basic_stack_context {
  public:
-  auto allocator() noexcept -> Alloc & { return m_allocator; }
+  auto allocator() noexcept -> Stack & { return m_allocator; }
 
  protected:
   constexpr basic_stack_context() = default;
 
   template <typename... Args>
-    requires std::constructible_from<Alloc, Args...> && (sizeof...(Args) > 0)
+    requires std::constructible_from<Stack, Args...> && (sizeof...(Args) > 0)
   explicit(sizeof...(Args) == 1) constexpr basic_stack_context(Args &&...args) noexcept(
-      std::is_nothrow_constructible_v<Alloc, Args...>)
+      std::is_nothrow_constructible_v<Stack, Args...>)
       : m_allocator(std::forward<Args>(args)...) {}
 
  private:
-  Alloc m_allocator;
+  Stack m_allocator;
 };
 
 /**
  * @brief A worker context polymorphic in push/pop.
  */
-export template <worker_stack Alloc>
-class basic_poly_context : public basic_stack_context<Alloc> {
+export template <worker_stack Stack>
+class basic_poly_context : public basic_stack_context<Stack> {
  public:
   virtual void post(sched_handle<basic_poly_context>) = 0;
   virtual void push(steal_handle<basic_poly_context>) = 0;
@@ -45,8 +45,8 @@ class basic_poly_context : public basic_stack_context<Alloc> {
  *  allocator method/member.
  *  constructors that forward to the allocator's constructors.
  */
-export template <bool Polymorphic, worker_stack Alloc>
-using context_base = std::conditional_t<Polymorphic, basic_poly_context<Alloc>, basic_stack_context<Alloc>>;
+export template <bool Polymorphic, worker_stack Stack>
+using context_base = std::conditional_t<Polymorphic, basic_poly_context<Stack>, basic_stack_context<Stack>>;
 
 // export using poly_env = env<basic_poly_context<geometric_stack>>;
 

--- a/src/core/poly_context.cxx
+++ b/src/core/poly_context.cxx
@@ -9,7 +9,7 @@ namespace lf {
 export template <worker_stack Stack>
 class basic_stack_context {
  public:
-  auto allocator() noexcept -> Stack & { return m_allocator; }
+  auto stack() noexcept -> Stack & { return m_stack; }
 
  protected:
   constexpr basic_stack_context() = default;
@@ -18,10 +18,10 @@ class basic_stack_context {
     requires std::constructible_from<Stack, Args...> && (sizeof...(Args) > 0)
   explicit(sizeof...(Args) == 1) constexpr basic_stack_context(Args &&...args) noexcept(
       std::is_nothrow_constructible_v<Stack, Args...>)
-      : m_allocator(std::forward<Args>(args)...) {}
+      : m_stack(std::forward<Args>(args)...) {}
 
  private:
-  Stack m_allocator;
+  Stack m_stack;
 };
 
 /**
@@ -42,8 +42,8 @@ class basic_poly_context : public basic_stack_context<Stack> {
  *
  * Provides:
  *  virtual push/pop/post/deleter if Polymorphic is true, otherwise provides no virtual functions.
- *  allocator method/member.
- *  constructors that forward to the allocator's constructors.
+ *  stack method/member.
+ *  constructors that forward to the stack's constructors.
  */
 export template <bool Polymorphic, worker_stack Stack>
 using context_base = std::conditional_t<Polymorphic, basic_poly_context<Stack>, basic_stack_context<Stack>>;

--- a/src/core/poly_context.cxx
+++ b/src/core/poly_context.cxx
@@ -31,8 +31,8 @@ export template <stack_allocator Alloc>
 class basic_poly_context : public basic_stack_context<Alloc> {
  public:
   virtual void post(sched_handle<basic_poly_context>) = 0;
-  virtual void push(frame_handle<basic_poly_context>) = 0;
-  virtual auto pop() noexcept -> frame_handle<basic_poly_context> = 0;
+  virtual void push(steal_handle<basic_poly_context>) = 0;
+  virtual auto pop() noexcept -> steal_handle<basic_poly_context> = 0;
 
   virtual ~basic_poly_context() noexcept = default;
 };

--- a/src/core/poly_context.cxx
+++ b/src/core/poly_context.cxx
@@ -30,7 +30,7 @@ class basic_stack_context {
 export template <stack_allocator Alloc>
 class basic_poly_context : public basic_stack_context<Alloc> {
  public:
-  virtual void post(await_handle<basic_poly_context>) = 0;
+  virtual void post(sched_handle<basic_poly_context>) = 0;
   virtual void push(frame_handle<basic_poly_context>) = 0;
   virtual auto pop() noexcept -> frame_handle<basic_poly_context> = 0;
 

--- a/src/core/poly_context.cxx
+++ b/src/core/poly_context.cxx
@@ -1,3 +1,5 @@
+module;
+#include "libfork/__impl/exception.hpp"
 export module libfork.core:poly_context;
 
 import std;
@@ -24,15 +26,22 @@ class basic_stack_context {
   Stack m_stack;
 };
 
+export struct post_error : std::runtime_error {
+  using std::runtime_error::runtime_error;
+};
+
 /**
- * @brief A worker context polymorphic in push/pop.
+ * @brief A worker context polymorphic in push/pop/post.
  */
 export template <worker_stack Stack>
 class basic_poly_context : public basic_stack_context<Stack> {
  public:
-  virtual void post(sched_handle<basic_poly_context>) = 0;
   virtual void push(steal_handle<basic_poly_context>) = 0;
   virtual auto pop() noexcept -> steal_handle<basic_poly_context> = 0;
+
+  virtual void post([[maybe_unused]] sched_handle<basic_poly_context> handle) {
+    LF_THROW(post_error{"Derived context does not support posting tasks."});
+  }
 
   virtual ~basic_poly_context() noexcept = default;
 };

--- a/src/core/poly_context.cxx
+++ b/src/core/poly_context.cxx
@@ -6,7 +6,7 @@ import :concepts;
 
 namespace lf {
 
-export template <stack_allocator Alloc>
+export template <worker_stack Alloc>
 class basic_stack_context {
  public:
   auto allocator() noexcept -> Alloc & { return m_allocator; }
@@ -27,7 +27,7 @@ class basic_stack_context {
 /**
  * @brief A worker context polymorphic in push/pop.
  */
-export template <stack_allocator Alloc>
+export template <worker_stack Alloc>
 class basic_poly_context : public basic_stack_context<Alloc> {
  public:
   virtual void post(sched_handle<basic_poly_context>) = 0;
@@ -45,7 +45,7 @@ class basic_poly_context : public basic_stack_context<Alloc> {
  *  allocator method/member.
  *  constructors that forward to the allocator's constructors.
  */
-export template <bool Polymorphic, stack_allocator Alloc>
+export template <bool Polymorphic, worker_stack Alloc>
 using context_base = std::conditional_t<Polymorphic, basic_poly_context<Alloc>, basic_stack_context<Alloc>>;
 
 // export using poly_env = env<basic_poly_context<geometric_stack>>;

--- a/src/core/promise.cxx
+++ b/src/core/promise.cxx
@@ -304,9 +304,9 @@ struct join_awaitable {
   frame_t<Context> *frame;
 
   constexpr auto take_stack_and_reset(this join_awaitable self) noexcept -> void {
-    Context *context = get_context<Context>();
-    LF_ASSUME(self.frame->stack_ckpt != context->allocator().checkpoint());
-    context->allocator().acquire(std::as_const(self.frame->stack_ckpt));
+    allocator_t<Context> &allocator = get_allocator<Context>();
+    LF_ASSUME(self.frame->stack_ckpt != allocator.checkpoint());
+    allocator.acquire(std::as_const(self.frame->stack_ckpt));
     self.frame->reset_counters();
   }
 

--- a/src/core/promise.cxx
+++ b/src/core/promise.cxx
@@ -188,9 +188,9 @@ constexpr auto final_suspend(frame_t<Context> *frame) noexcept -> coro<> {
 
       Context *context = get_context<Context>();
 
-      if (frame_handle<Context> last_pushed = context->pop()) {
+      if (steal_handle<Context> last_pushed = context->pop()) {
         // No-one stole continuation, we are the exclusive owner of parent -> just keep ripping!
-        LF_ASSUME(last_pushed == frame_handle<Context>{key(), parent});
+        LF_ASSUME(last_pushed == steal_handle<Context>{key(), parent});
         // This is not a join point so no state (i.e. counters) is guaranteed.
         return parent->handle();
       }
@@ -284,7 +284,7 @@ struct awaitable : std::suspend_always {
       // use-after-free to then access self in the following line to fetch the
       // handle.
       LF_TRY {
-        get_context<Context>()->push(frame_handle<Context>{key(), &parent.promise().frame});
+        get_context<Context>()->push(steal_handle<Context>{key(), &parent.promise().frame});
       } LF_CATCH_ALL {
         return self.stash_and_resume(parent), parent;
       }

--- a/src/core/promise.cxx
+++ b/src/core/promise.cxx
@@ -24,7 +24,7 @@ template <typename T = void>
 using coro = std::coroutine_handle<T>;
 
 template <worker_context Context>
-using frame_t = frame_type<checkpoint_t<allocator_t<Context>>>;
+using frame_t = frame_type<checkpoint_t<stack_t<Context>>>;
 
 // =============== Forward-decl =============== //
 
@@ -98,7 +98,7 @@ final_suspend_continue(Context *context, frame_t<Context> *parent) noexcept -> c
   // to access as it may be resumed and then destroyed by another thread. Hence
   // we must make copies on-the-stack of any data we may need if we lose the
   // join race.
-  bool const owner = parent->stack_ckpt == context->allocator().checkpoint();
+  bool const owner = parent->stack_ckpt == context->stack().checkpoint();
 
   // TODO: we could reduce branching if we unconditionally release and also
   // drop pre-release function altogether... Need to benchmark with code that
@@ -106,7 +106,7 @@ final_suspend_continue(Context *context, frame_t<Context> *parent) noexcept -> c
 
   // As soon as we do the fetch_sub (if we loose) someone may acquire
   // the stack so we must prepare it for release now.
-  auto release_key = context->allocator().prepare_release();
+  auto release_key = context->stack().prepare_release();
 
   // TODO: we could add an `if (owner)` around acquire below, then we could
   // define that acquire is always called with null or not-self.
@@ -120,7 +120,7 @@ final_suspend_continue(Context *context, frame_t<Context> *parent) noexcept -> c
 
     if (!owner) {
       // In case of scenario (2) we must acquire the parent's stack.
-      context->allocator().acquire(std::as_const(parent->stack_ckpt));
+      context->stack().acquire(std::as_const(parent->stack_ckpt));
     }
 
     // Must reset parent's control block before resuming parent.
@@ -137,7 +137,7 @@ final_suspend_continue(Context *context, frame_t<Context> *parent) noexcept -> c
   if (owner) {
     // We were unable to resume the parent and we were its owner, as the
     // resuming thread will take ownership of the parent's we must give it up.
-    context->allocator().release(std::move(release_key));
+    context->stack().release(std::move(release_key));
   }
 
   // Else, case (2), our stack has no allocations on it, it may be used later.
@@ -304,9 +304,9 @@ struct join_awaitable {
   frame_t<Context> *frame;
 
   constexpr auto take_stack_and_reset(this join_awaitable self) noexcept -> void {
-    allocator_t<Context> &allocator = get_stack<Context>();
-    LF_ASSUME(self.frame->stack_ckpt != allocator.checkpoint());
-    allocator.acquire(std::as_const(self.frame->stack_ckpt));
+    stack_t<Context> &stack = get_stack<Context>();
+    LF_ASSUME(self.frame->stack_ckpt != stack.checkpoint());
+    stack.acquire(std::as_const(self.frame->stack_ckpt));
     self.frame->reset_counters();
   }
 
@@ -443,9 +443,7 @@ struct mixin_frame {
     return std::assume_aligned<k_new_align>(ptr);
   }
 
-  static auto operator delete(void *p, std::size_t sz) noexcept -> void {
-    get_stack<Context>().pop(p, sz);
-  }
+  static auto operator delete(void *p, std::size_t sz) noexcept -> void { get_stack<Context>().pop(p, sz); }
 
   // --- Await transformations
 

--- a/src/core/promise.cxx
+++ b/src/core/promise.cxx
@@ -304,7 +304,7 @@ struct join_awaitable {
   frame_t<Context> *frame;
 
   constexpr auto take_stack_and_reset(this join_awaitable self) noexcept -> void {
-    allocator_t<Context> &allocator = get_allocator<Context>();
+    allocator_t<Context> &allocator = get_stack<Context>();
     LF_ASSUME(self.frame->stack_ckpt != allocator.checkpoint());
     allocator.acquire(std::as_const(self.frame->stack_ckpt));
     self.frame->reset_counters();
@@ -437,14 +437,14 @@ struct mixin_frame {
 
   // --- Allocation
 
-  static auto operator new(std::size_t sz) noexcept(noexcept(get_allocator<Context>().push(sz))) -> void * {
-    void *ptr = get_allocator<Context>().push(sz);
+  static auto operator new(std::size_t sz) noexcept(noexcept(get_stack<Context>().push(sz))) -> void * {
+    void *ptr = get_stack<Context>().push(sz);
     LF_ASSUME(is_sufficiently_aligned<k_new_align>(ptr));
     return std::assume_aligned<k_new_align>(ptr);
   }
 
   static auto operator delete(void *p, std::size_t sz) noexcept -> void {
-    get_allocator<Context>().pop(p, sz);
+    get_stack<Context>().pop(p, sz);
   }
 
   // --- Await transformations
@@ -514,7 +514,7 @@ struct promise_type<void, Context> : mixin_frame<Context> {
   // Putting init here allows:
   //  1. Frame not no need to know about the checkpoint type
   //  2. Compiler merge double read of thread local here and in allocator
-  frame_t<Context> frame{get_allocator<Context>().checkpoint()};
+  frame_t<Context> frame{get_stack<Context>().checkpoint()};
 
   constexpr auto get_return_object() noexcept -> task<void, Context> { return {key(), this}; }
 
@@ -529,7 +529,7 @@ struct promise_type : mixin_frame<Context> {
   // Putting init here allows:
   //  1. Frame not no need to know about the checkpoint type
   //  2. Compiler merge double read of thread local here and in allocator
-  frame_t<Context> frame{get_allocator<Context>().checkpoint()};
+  frame_t<Context> frame{get_stack<Context>().checkpoint()};
   T *return_address;
 
   constexpr auto get_return_object() noexcept -> task<T, Context> { return {key(), this}; }

--- a/src/core/schedule.cxx
+++ b/src/core/schedule.cxx
@@ -64,7 +64,7 @@ schedule(Context *context, Fn &&fn, Args &&...args) noexcept -> async_result_t<F
   // TODO: expose cancellable?
   promise->frame.parent.block = root_block.get();
   promise->frame.cancel = nullptr;
-  promise->frame.stack_ckpt = get_allocator<Context>().checkpoint();
+  promise->frame.stack_ckpt = get_stack<Context>().checkpoint();
   promise->frame.kind = lf::category::root;
 
   if constexpr (!std::is_void_v<result_type>) {
@@ -117,7 +117,7 @@ schedule2(Context &context, Fn &&fn, Args &&...args) noexcept -> async_result_t<
   // TODO: expose cancellable?
   promise->frame.parent.block = root_block.get();
   promise->frame.cancel = nullptr;
-  promise->frame.stack_ckpt = get_allocator<Context>().checkpoint();
+  promise->frame.stack_ckpt = get_stack<Context>().checkpoint();
   promise->frame.kind = lf::category::root;
 
   if constexpr (!std::is_void_v<result_type>) {

--- a/src/core/schedule.cxx
+++ b/src/core/schedule.cxx
@@ -82,4 +82,57 @@ schedule(Context *context, Fn &&fn, Args &&...args) noexcept -> async_result_t<F
   }
 }
 
+export struct schedule_error : std::runtime_error {
+  using std::runtime_error::runtime_error;
+};
+
+export template <worker_context Context, typename... Args, async_invocable<Context, Args...> Fn>
+  requires void_or_default_initializable<async_result_t<Fn, Context, Args...>>
+constexpr auto
+schedule2(Context &context, Fn &&fn, Args &&...args) noexcept -> async_result_t<Fn, Context, Args...> {
+
+  // TODO: make sure this is exception safe and correctly qualifed
+
+  LF_ASSUME(context != nullptr);
+
+  if (thread_context<Context> != nullptr) {
+    LF_THROW(schedule_error{"Schedule called from within a worker thread!"});
+  }
+
+  // This is what the async function will return.
+  using result_type = async_result_t<Fn, Context, Args...>;
+
+  auto root_block = std::unique_ptr<block<result_type>, block_deleter>{new block<result_type>{}};
+
+  // TODO: clean up block if exception
+  // TODO: make sure we're cancel safe
+
+  // TODO: Before doing this we must be on a valid context.
+  LF_ASSUME(get_context<Context>() == context);
+
+  // The following invocation of the async function will access `context`
+
+  auto *promise = get(key(), ctx_invoke_t<Context>{}(std::forward<Fn>(fn), std::forward<Args>(args)...));
+
+  // TODO: expose cancellable?
+  promise->frame.parent.block = root_block.get();
+  promise->frame.cancel = nullptr;
+  promise->frame.stack_ckpt = get_allocator<Context>().checkpoint();
+  promise->frame.kind = lf::category::root;
+
+  if constexpr (!std::is_void_v<result_type>) {
+    promise->return_address = &root_block->return_value;
+  }
+
+  promise->handle().resume();
+
+  root_block->sem.acquire();
+
+  if constexpr (!std::is_void_v<result_type>) {
+    return root_block->return_value;
+  } else {
+    return;
+  }
+}
+
 } // namespace lf

--- a/src/core/stacks/dummy.cxx
+++ b/src/core/stacks/dummy.cxx
@@ -3,7 +3,7 @@ export module libfork.core:dummy_stack;
 
 import std;
 
-namespace lf {
+namespace lf::stacks {
 
 export struct dummy_allocator {
 

--- a/src/core/stacks/dummy.cxx
+++ b/src/core/stacks/dummy.cxx
@@ -1,4 +1,3 @@
-module;
 export module libfork.core:dummy_stack;
 
 import std;

--- a/src/core/stacks/dummy.cxx
+++ b/src/core/stacks/dummy.cxx
@@ -21,4 +21,4 @@ export struct dummy_allocator {
   constexpr static auto acquire(ckpt) noexcept -> void;
 };
 
-} // namespace lf
+} // namespace lf::stacks

--- a/src/core/stacks/geometric.cxx
+++ b/src/core/stacks/geometric.cxx
@@ -17,7 +17,7 @@ namespace lf::stack {
  *
  * This protects against hot-splitting by keeping a single cached segment.
  *
- * For this to conform to `stack_allocator` the allocators void pointer type must be `void *`
+ * For this to conform to `worker_stack` the allocators void pointer type must be `void *`
  */
 export template <allocator_of<std::byte> Allocator = std::allocator<std::byte>>
 class geometric {

--- a/src/core/stacks/geometric.cxx
+++ b/src/core/stacks/geometric.cxx
@@ -10,7 +10,7 @@ import :constants;
 import :utility;
 import :concepts;
 
-namespace lf::stack {
+namespace lf::stacks {
 
 /**
  * @brief A geometric_stack is a user-space (geometric) segmented program stack.
@@ -447,4 +447,4 @@ class geometric {
   }
 };
 
-} // namespace lf::stack
+} // namespace lf::stacks

--- a/src/core/thread_locals.cxx
+++ b/src/core/thread_locals.cxx
@@ -24,7 +24,7 @@ constexpr auto get_context() noexcept -> Context * {
 }
 
 template <worker_context Context>
-constexpr auto get_allocator() noexcept -> allocator_t<Context> & {
+constexpr auto get_stack() noexcept -> allocator_t<Context> & {
   return get_context<Context>()->allocator();
 }
 

--- a/src/core/thread_locals.cxx
+++ b/src/core/thread_locals.cxx
@@ -13,6 +13,8 @@ namespace lf {
 export template <worker_context Context>
 constinit inline thread_local Context *thread_context = nullptr;
 
+// TODO: return a reference
+
 /**
  * @brief A getter for the current worker context, checks for null in debug.
  */

--- a/src/core/thread_locals.cxx
+++ b/src/core/thread_locals.cxx
@@ -13,7 +13,7 @@ namespace lf {
 export template <worker_context Context>
 constinit inline thread_local Context *thread_context = nullptr;
 
-// TODO: return a reference
+// TODO: return a reference, rename to get_tls_*
 
 /**
  * @brief A getter for the current worker context, checks for null in debug.
@@ -24,8 +24,8 @@ constexpr auto get_context() noexcept -> Context * {
 }
 
 template <worker_context Context>
-constexpr auto get_stack() noexcept -> allocator_t<Context> & {
-  return get_context<Context>()->allocator();
+constexpr auto get_stack() noexcept -> stack_t<Context> & {
+  return get_context<Context>()->stack();
 }
 
 } // namespace lf

--- a/src/schedule/dummy.cxx
+++ b/src/schedule/dummy.cxx
@@ -1,4 +1,3 @@
-module;
 export module libfork.schedule:dummy_context;
 
 import std;

--- a/src/schedule/dummy.cxx
+++ b/src/schedule/dummy.cxx
@@ -1,5 +1,5 @@
 module;
-export module libfork.context:dummy_context;
+export module libfork.schedule:dummy_context;
 
 import std;
 

--- a/src/schedule/inline.cxx
+++ b/src/schedule/inline.cxx
@@ -1,5 +1,5 @@
 module;
-export module libfork.context:inline_context;
+export module libfork.schedule:inline_context;
 
 import std;
 

--- a/src/schedule/schedule.cxx
+++ b/src/schedule/schedule.cxx
@@ -1,4 +1,4 @@
-export module libfork.context;
+export module libfork.schedule;
 
 export import :dummy_context;
 export import :inline_context;

--- a/src/schedule/schedule.cxx
+++ b/src/schedule/schedule.cxx
@@ -1,4 +1,3 @@
 export module libfork.schedule;
 
 export import :dummy_context;
-export import :inline_context;

--- a/test/src/concepts.cpp
+++ b/test/src/concepts.cpp
@@ -114,7 +114,7 @@ TEST_CASE("Concepts: async_invocable", "[concepts]") {
   // Need a valid context of a different type
   struct mock_context {
     void push(lf::frame_handle<mock_context>);
-    void post(lf::await_handle<mock_context>);
+    void post(lf::sched_handle<mock_context>);
     auto pop() noexcept -> lf::frame_handle<mock_context>;
     auto allocator() noexcept -> dummy_allocator &;
   };

--- a/test/src/concepts.cpp
+++ b/test/src/concepts.cpp
@@ -58,14 +58,14 @@ TEST_CASE("Concepts: returnable", "[concepts]") {
   STATIC_REQUIRE_FALSE(returnable<non_movable>);
 }
 
-TEST_CASE("Concepts: stack_allocator", "[concepts]") {
-  STATIC_REQUIRE(stack_allocator<dummy_allocator>);
+TEST_CASE("Concepts: worker_stack", "[concepts]") {
+  STATIC_REQUIRE(worker_stack<dummy_allocator>);
 
   struct bad_alloc : dummy_allocator {
     constexpr static auto pop(void *p, std::size_t sz) -> void;
   };
 
-  STATIC_REQUIRE_FALSE(stack_allocator<bad_alloc>);
+  STATIC_REQUIRE_FALSE(worker_stack<bad_alloc>);
 }
 
 TEST_CASE("Concepts: worker_context", "[concepts]") {

--- a/test/src/concepts.cpp
+++ b/test/src/concepts.cpp
@@ -74,7 +74,7 @@ TEST_CASE("Concepts: worker_context", "[concepts]") {
   struct missing_post {
     void push(lf::steal_handle<missing_post>);
     auto pop() noexcept -> lf::steal_handle<missing_post>;
-    auto allocator() noexcept -> dummy_allocator &;
+    auto stack() noexcept -> dummy_allocator &;
   };
 
   STATIC_REQUIRE_FALSE(worker_context<missing_post>);
@@ -116,7 +116,7 @@ TEST_CASE("Concepts: async_invocable", "[concepts]") {
     void push(lf::steal_handle<mock_context>);
     void post(lf::sched_handle<mock_context>);
     auto pop() noexcept -> lf::steal_handle<mock_context>;
-    auto allocator() noexcept -> dummy_allocator &;
+    auto stack() noexcept -> dummy_allocator &;
   };
 
   STATIC_REQUIRE(worker_context<mock_context>);

--- a/test/src/concepts.cpp
+++ b/test/src/concepts.cpp
@@ -116,7 +116,7 @@ TEST_CASE("Concepts: async_invocable", "[concepts]") {
     void push(lf::steal_handle<mock_context>);
     void post(lf::sched_handle<mock_context>);
     auto pop() noexcept -> lf::steal_handle<mock_context>;
-    auto stack() noexcept ->stacks:: dummy_allocator &;
+    auto stack() noexcept -> stacks::dummy_allocator &;
   };
 
   STATIC_REQUIRE(worker_context<mock_context>);

--- a/test/src/concepts.cpp
+++ b/test/src/concepts.cpp
@@ -59,9 +59,9 @@ TEST_CASE("Concepts: returnable", "[concepts]") {
 }
 
 TEST_CASE("Concepts: worker_stack", "[concepts]") {
-  STATIC_REQUIRE(worker_stack<dummy_allocator>);
+  STATIC_REQUIRE(worker_stack<stacks::dummy_allocator>);
 
-  struct bad_alloc : dummy_allocator {
+  struct bad_alloc : stacks::dummy_allocator {
     constexpr static auto pop(void *p, std::size_t sz) -> void;
   };
 
@@ -74,7 +74,7 @@ TEST_CASE("Concepts: worker_context", "[concepts]") {
   struct missing_post {
     void push(lf::steal_handle<missing_post>);
     auto pop() noexcept -> lf::steal_handle<missing_post>;
-    auto stack() noexcept -> dummy_allocator &;
+    auto stack() noexcept -> stacks::dummy_allocator &;
   };
 
   STATIC_REQUIRE_FALSE(worker_context<missing_post>);
@@ -116,7 +116,7 @@ TEST_CASE("Concepts: async_invocable", "[concepts]") {
     void push(lf::steal_handle<mock_context>);
     void post(lf::sched_handle<mock_context>);
     auto pop() noexcept -> lf::steal_handle<mock_context>;
-    auto stack() noexcept -> dummy_allocator &;
+    auto stack() noexcept ->stacks:: dummy_allocator &;
   };
 
   STATIC_REQUIRE(worker_context<mock_context>);

--- a/test/src/concepts.cpp
+++ b/test/src/concepts.cpp
@@ -3,7 +3,7 @@
 import std;
 
 import libfork.core;
-import libfork.context;
+import libfork.schedule;
 
 using namespace lf;
 

--- a/test/src/concepts.cpp
+++ b/test/src/concepts.cpp
@@ -72,8 +72,8 @@ TEST_CASE("Concepts: worker_context", "[concepts]") {
   STATIC_REQUIRE(worker_context<dummy_context>);
 
   struct missing_post {
-    void push(lf::frame_handle<missing_post>);
-    auto pop() noexcept -> lf::frame_handle<missing_post>;
+    void push(lf::steal_handle<missing_post>);
+    auto pop() noexcept -> lf::steal_handle<missing_post>;
     auto allocator() noexcept -> dummy_allocator &;
   };
 
@@ -113,9 +113,9 @@ TEST_CASE("Concepts: async_invocable", "[concepts]") {
 
   // Need a valid context of a different type
   struct mock_context {
-    void push(lf::frame_handle<mock_context>);
+    void push(lf::steal_handle<mock_context>);
     void post(lf::sched_handle<mock_context>);
-    auto pop() noexcept -> lf::frame_handle<mock_context>;
+    auto pop() noexcept -> lf::steal_handle<mock_context>;
     auto allocator() noexcept -> dummy_allocator &;
   };
 

--- a/test/src/concepts.cpp
+++ b/test/src/concepts.cpp
@@ -71,13 +71,12 @@ TEST_CASE("Concepts: worker_stack", "[concepts]") {
 TEST_CASE("Concepts: worker_context", "[concepts]") {
   STATIC_REQUIRE(worker_context<dummy_context>);
 
-  struct missing_post {
-    void push(lf::steal_handle<missing_post>);
-    auto pop() noexcept -> lf::steal_handle<missing_post>;
+  struct missing_push {
+    auto pop() noexcept -> lf::steal_handle<missing_push>;
     auto stack() noexcept -> stacks::dummy_allocator &;
   };
 
-  STATIC_REQUIRE_FALSE(worker_context<missing_post>);
+  STATIC_REQUIRE_FALSE(worker_context<missing_push>);
 }
 
 TEST_CASE("Concepts: async_invocable", "[concepts]") {

--- a/test/src/promise.cpp
+++ b/test/src/promise.cpp
@@ -1,7 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 import libfork.core;
-import libfork.context;
+import libfork.schedule;
 
 // TODO: make the tests part of the module so they can access the internals?
 

--- a/test/src/promise.cpp
+++ b/test/src/promise.cpp
@@ -7,7 +7,7 @@ import libfork.context;
 
 TEST_CASE("Promise test", "[promise]") {
 
-  using ckpt_t = lf::checkpoint_t<lf::allocator_t<lf::dummy_context>>;
+  using ckpt_t = lf::checkpoint_t<lf::stack_t<lf::dummy_context>>;
   using frame_t = lf::frame_type<ckpt_t>;
 
   // Check for safe reinterpret_casts

--- a/test/src/stack.cpp
+++ b/test/src/stack.cpp
@@ -40,12 +40,12 @@ constexpr void check_alignment(void *ptr) {
 } // namespace
 
 TEST_CASE("Concept", "[geometric_stack]") {
-  STATIC_REQUIRE(worker_stack<lf::stack::geometric<>>); //
+  STATIC_REQUIRE(worker_stack<lf::stacks::geometric<>>); //
 }
 
 TEST_CASE("Basic push and pop", "[geometric_stack]") {
   TEST_CONSTEXPR([]() -> bool {
-    lf::stack::geometric<> stack;
+    lf::stacks::geometric<> stack;
     expect(stack.empty());
 
     void *p1 = stack.push(10);
@@ -68,11 +68,11 @@ TEST_CASE("Basic push and pop", "[geometric_stack]") {
 
 TEST_CASE("Checkpoint and Acquire/Release", "[geometric_stack]") {
   TEST_CONSTEXPR([]() -> bool {
-    lf::stack::geometric<> stack1;
+    lf::stacks::geometric<> stack1;
     void *p1 = stack1.push(100);
     auto cp1 = stack1.checkpoint();
 
-    lf::stack::geometric<> stack2;
+    lf::stacks::geometric<> stack2;
     auto cp2 = stack2.checkpoint();
     expect(cp1 != cp2);
 
@@ -89,7 +89,7 @@ TEST_CASE("Checkpoint and Acquire/Release", "[geometric_stack]") {
 TEST_CASE("Stress test", "[geometric_stack]") {
   for (int k = 0; k < 10; ++k) {
 
-    lf::stack::geometric<> stack;
+    lf::stacks::geometric<> stack;
     std::mt19937_64 rng{std::random_device{}()};
     std::uniform_int_distribution<std::size_t> size_dist{1, 200};
     std::uniform_int_distribution<std::size_t> depth_dist{5, 5000};
@@ -124,7 +124,7 @@ TEST_CASE("Stress test", "[geometric_stack]") {
 }
 
 TEST_CASE("Randomized push/pop stress test", "[geometric_stack]") {
-  lf::stack::geometric<> stack;
+  lf::stacks::geometric<> stack;
   std::mt19937_64 rng{std::random_device{}()};
   std::bernoulli_distribution push_dist{0.51};
   std::uniform_int_distribution<std::size_t> size_dist{1, 512};
@@ -167,7 +167,7 @@ TEST_CASE("Randomized push/pop stress test", "[geometric_stack]") {
 }
 
 TEST_CASE("Spikey randomized push/pop stress test", "[geometric_stack]") {
-  lf::stack::geometric<> stack;
+  lf::stacks::geometric<> stack;
   std::mt19937_64 rng{std::random_device{}()};
 
   // Higher probability of push after push, higher probability of pop after pop

--- a/test/src/stack.cpp
+++ b/test/src/stack.cpp
@@ -4,7 +4,7 @@ import std;
 import libfork.core;
 
 using lf::k_new_align;
-using lf::stack_allocator;
+using lf::worker_stack;
 
 namespace {
 
@@ -40,7 +40,7 @@ constexpr void check_alignment(void *ptr) {
 } // namespace
 
 TEST_CASE("Concept", "[geometric_stack]") {
-  STATIC_REQUIRE(stack_allocator<lf::stack::geometric<>>); //
+  STATIC_REQUIRE(worker_stack<lf::stack::geometric<>>); //
 }
 
 TEST_CASE("Basic push and pop", "[geometric_stack]") {


### PR DESCRIPTION
Multi component PR, mainly refactors with initial sketch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Reorganized module structure: `libfork.context` module removed and replaced with `libfork.schedule` module
  * Renamed handle types and allocator APIs for improved clarity

* **New Features**
  * Added new scheduling entry point with thread context validation
  * Introduced new exception types for enhanced error reporting during scheduling operations

* **Internal Improvements**
  * Refactored core architecture with new generic context infrastructure
  * Updated benchmark implementations to use new scheduling APIs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->