### PR TITLE
[V4] Schedule split 2/n

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,7 @@ target_sources(libfork_libfork
       src/core/handles.cxx
       src/core/root.cxx
       src/core/execute.cxx
+      src/core/receiver.cxx
       # core.stacks
       src/core/stacks/geometric.cxx
       src/core/stacks/dummy.cxx

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,7 @@ target_sources(libfork_libfork
       src/core/deque.cxx
       src/core/schedule.cxx
       src/core/handles.cxx
+      src/core/root.cxx
       src/core/stacks/geometric.cxx
       src/core/stacks/dummy.cxx
       # Schedule

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,7 @@ target_sources(libfork_libfork
       src/core/stacks/dummy.cxx
       # Schedule
       src/schedule/schedule.cxx
+      src/schedule/inline.cxx
       src/schedule/dummy.cxx
     PRIVATE
       src/exception.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ target_sources(libfork_libfork
 target_sources(libfork_libfork
   PUBLIC
     FILE_SET CXX_MODULES FILES
-     # Core
+      # core
       src/core/core.cxx
       src/core/promise.cxx
       src/core/concepts.cxx
@@ -72,9 +72,11 @@ target_sources(libfork_libfork
       src/core/schedule.cxx
       src/core/handles.cxx
       src/core/root.cxx
+      src/core/execute.cxx
+      # core.stacks
       src/core/stacks/geometric.cxx
       src/core/stacks/dummy.cxx
-      # Schedule
+      # schedule
       src/schedule/schedule.cxx
       src/schedule/inline.cxx
       src/schedule/dummy.cxx

--- a/include/libfork/__impl/assume.hpp
+++ b/include/libfork/__impl/assume.hpp
@@ -45,3 +45,12 @@
 #else
   #define LF_ASSUME(...) LF_ENSURE(__VA_ARGS__)
 #endif
+
+#ifdef NDEBUG
+  #define LF_UNREACHABLE()                                                                                   \
+    do {                                                                                                     \
+      ::std::unreachable();                                                                                  \
+    } while (false)
+#else
+  #define LF_UNREACHABLE() LF_TERMINATE("This code should be unreachable!");
+#endif

--- a/src/core/concepts.cxx
+++ b/src/core/concepts.cxx
@@ -173,6 +173,9 @@ concept scheduler = requires (T sched, sched_handle<typename std::remove_cvref_t
   { sched.post(handle) } -> std::same_as<void>;
 };
 
+template <scheduler Sch>
+using context_t = typename std::remove_cvref_t<Sch>::context_type;
+
 // ==== Forward-decl
 
 export template <worker_context>
@@ -198,7 +201,7 @@ struct ctx_invoke_t {
       LF_HOF(std::invoke(std::forward<Fn>(fn), std::forward<Args>(args)...))
 };
 
-template <typename R, typename Context>
+template <typename Context, typename R>
 concept task_from = specialization_of<R, task> && std::same_as<Context, typename R::context_type>;
 
 /**
@@ -207,7 +210,7 @@ concept task_from = specialization_of<R, task> && std::same_as<Context, typename
 export template <typename Fn, typename Context, typename... Args>
 concept async_invocable = worker_context<Context> &&                                                    //
                           std::invocable<ctx_invoke_t<Context>, Fn, Args...> &&                         //
-                          task_from<std::invoke_result_t<ctx_invoke_t<Context>, Fn, Args...>, Context>; //
+                          task_from<Context, std::invoke_result_t<ctx_invoke_t<Context>, Fn, Args...>>; //
 
 /**
  * @brief Subsumes `async_invocable` and checks that the invocation is `noexcept`.

--- a/src/core/concepts.cxx
+++ b/src/core/concepts.cxx
@@ -118,12 +118,6 @@ concept worker_stack = plain_object<T> && requires (T stack, std::size_t n, void
   { stack.acquire(constify(stack.checkpoint())) } noexcept -> std::same_as<void>;
 };
 
-/**
- * @brief Fetch the checkpoint type of a stack `T`.
- */
-export template <worker_stack T>
-using checkpoint_t = decltype(std::declval<T &>().checkpoint());
-
 // ==== Context
 
 export template <typename T>
@@ -157,6 +151,12 @@ concept worker_context =
  */
 export template <worker_context T>
 using stack_t = std::remove_reference_t<decltype(std::declval<T &>().stack())>;
+
+/**
+ * @brief Fetch the checkpoint type of a worker context `T`.
+ */
+export template <worker_context T>
+using checkpoint_t = decltype(std::declval<stack_t<T> &>().checkpoint());
 
 // ==== Scheduler
 

--- a/src/core/core.cxx
+++ b/src/core/core.cxx
@@ -8,26 +8,18 @@ export module libfork.core;
 // polymorphic context
 // conformant stacks
 
-// T1 partitions
 export import :concepts;
 export import :constants;
 export import :utility;
 export import :tuple;
 export import :geometric_stack;
 export import :dummy_stack;
-
-// T2 partitions
-export import :frame;         // concepts, constants
-export import :deque;         // concepts, constants, utility
-export import :thread_locals; // concepts
-export import :poly_context;  // concepts
-
-// T3 partitions
-export import :ops;     // concepts, utility, tuple, frame
-export import :handles; // frame
-
-// T4 partitions
-export import :promise; // concepts, frame, utility, thread_locals, ops, handles
-
-// T5 partitions
-export import :schedule; // concepts, frame, thread_locals, promise
+export import :frame;
+export import :deque;
+export import :thread_locals;
+export import :poly_context;
+export import :ops;
+export import :handles;
+export import :promise;
+export import :schedule;
+export import :root;

--- a/src/core/core.cxx
+++ b/src/core/core.cxx
@@ -25,3 +25,4 @@ export import :promise;
 export import :schedule;
 export import :root;
 export import :execute;
+export import :receiver;

--- a/src/core/core.cxx
+++ b/src/core/core.cxx
@@ -24,3 +24,4 @@ export import :handles;
 export import :promise;
 export import :schedule;
 export import :root;
+export import :execute;

--- a/src/core/core.cxx
+++ b/src/core/core.cxx
@@ -18,6 +18,7 @@ export import :frame;
 export import :deque;
 export import :thread_locals;
 export import :poly_context;
+export import :generic_context;
 export import :ops;
 export import :handles;
 export import :promise;

--- a/src/core/deque.cxx
+++ b/src/core/deque.cxx
@@ -1,8 +1,6 @@
 module;
 #include "libfork/__impl/assume.hpp"
-// #include "libfork/__impl/compiler.hpp"
-// #include "libfork/__impl/exception.hpp"
-// #include "libfork/__impl/utils.hpp"
+#include "libfork/__impl/exception.hpp"
 export module libfork.core:deque;
 
 import std;

--- a/src/core/execute.cxx
+++ b/src/core/execute.cxx
@@ -1,0 +1,12 @@
+
+module;
+#include "libfork/__impl/assume.hpp"
+export module libfork.core:execute;
+
+import std;
+
+namespace lf {
+
+//
+
+}

--- a/src/core/execute.cxx
+++ b/src/core/execute.cxx
@@ -8,6 +8,7 @@ import std;
 import :thread_locals;
 import :concepts;
 import :handles;
+import :utility;
 
 namespace lf {
 

--- a/src/core/execute.cxx
+++ b/src/core/execute.cxx
@@ -5,8 +5,36 @@ export module libfork.core:execute;
 
 import std;
 
+import :thread_locals;
+import :concepts;
+import :handles;
+
 namespace lf {
 
-//
+// TODO: unify exception higerarchy
 
+/**
+ * @brief Bind this thread to a context and execute the scheduled tasks on that context/thread.
+ *
+ * This should not be called from a thread already bound to a context, once this call returns
+ * the thread is unbound from the context.
+ */
+export template <worker_context Context>
+constexpr void execute(Context &context, sched_handle<Context> handle) {
+
+  if (thread_context<Context> != nullptr) {
+    LF_THROW(std::runtime_error{"execute called from within a worker thread!"});
+  }
+
+  thread_context<Context> = std::addressof(context);
+
+  defer _ = [] noexcept -> void {
+    thread_context<Context> = nullptr;
+  };
+
+  auto *frame = static_cast<frame_type<checkpoint_t<Context>> *>(get(key(), handle));
+
+  frame->handle().resume();
 }
+
+} // namespace lf

--- a/src/core/frame.cxx
+++ b/src/core/frame.cxx
@@ -60,8 +60,6 @@ export struct frame_base {};
 export template <typename Checkpoint>
 struct frame_type : frame_base {
 
-  using checkpoint_type = Checkpoint;
-
   union parent_union {
     frame_type *frame;
     block_type *block;
@@ -85,7 +83,7 @@ struct frame_type : frame_base {
 
   // TODO: drop default constructible requirement?
   [[no_unique_address]]
-  checkpoint_type stack_ckpt;
+  Checkpoint stack_ckpt;
 
   ATOMIC_ALIGN(std::uint32_t) joins = 0;        // Atomic is 32 bits for speed
   std::uint16_t steals = 0;                     // In debug do overflow checking
@@ -97,7 +95,7 @@ struct frame_type : frame_base {
   // Explicitly post construction, this allows the compiler to emit a single
   // instruction for the zero init then an instruction for the joins init,
   // instead of three instructions.
-  constexpr frame_type(checkpoint_type &&ckpt) noexcept : stack_ckpt(std::move(ckpt)) { joins = k_u16_max; }
+  constexpr frame_type(Checkpoint &&ckpt) noexcept : stack_ckpt(std::move(ckpt)) { joins = k_u16_max; }
 
   [[nodiscard]]
   constexpr auto is_cancelled() const noexcept -> bool {

--- a/src/core/generic_context.cxx
+++ b/src/core/generic_context.cxx
@@ -55,16 +55,9 @@ class generic_context final : context_base<Polymorphic, Stack> {
 
   using base_type::stack;
 
-  constexpr void push(steal_h frame) { m_container.push_back(frame); }
+  constexpr void push(steal_h frame) { m_container.push(frame); }
 
-  constexpr auto pop() noexcept -> steal_h {
-    if (!m_container.empty()) {
-      steal_h frame = m_container.back();
-      m_container.pop_back();
-      return frame;
-    }
-    return {};
-  }
+  constexpr auto pop() noexcept -> steal_h { return m_container.pop(); }
 
   // constexpr void post(sched_h frame) {}
 

--- a/src/core/generic_context.cxx
+++ b/src/core/generic_context.cxx
@@ -26,17 +26,17 @@ class vector_stack {
   std::vector<T, Allocator> m_vector;
 };
 
-export template <                                                  //
-    bool Polymorphic,                                              //
-    worker_stack Stack,                                            //
-    template <typename, typename> typename Container = std::vector //
+export template <                                                   //
+    bool Polymorphic,                                               //
+    worker_stack Stack,                                             //
+    template <typename, typename> typename Container = vector_stack //
     >
-class inline_context final : context_base<Polymorphic, Stack> {
+class generic_context final : context_base<Polymorphic, Stack> {
 
   using base_type = context_base<Polymorphic, Stack>;
 
  public:
-  using context_type = std::conditional_t<Polymorphic, base_type, inline_context>;
+  using context_type = std::conditional_t<Polymorphic, base_type, generic_context>;
 
  private:
   using sched_h = sched_handle<context_type>;

--- a/src/core/handles.cxx
+++ b/src/core/handles.cxx
@@ -33,10 +33,10 @@ class handle {
   constexpr handle(key_t, frame_base *ptr) noexcept : m_ptr{ptr} {}
 
  private:
-  // [[nodiscard]]
-  // constexpr friend auto get(key_t, handle<U> other) noexcept -> frame_type<U> * {
-  //   return static_cast<frame_type<U> *>(other.m_ptr);
-  // }
+  [[nodiscard]]
+  constexpr friend auto get(key_t, handle other) noexcept -> frame_base * {
+    return other.m_ptr;
+  }
 
   frame_base *m_ptr = nullptr;
 };

--- a/src/core/promise.cxx
+++ b/src/core/promise.cxx
@@ -24,7 +24,7 @@ template <typename T = void>
 using coro = std::coroutine_handle<T>;
 
 template <worker_context Context>
-using frame_t = frame_type<checkpoint_t<stack_t<Context>>>;
+using frame_t = frame_type<checkpoint_t<Context>>;
 
 // =============== Forward-decl =============== //
 

--- a/src/core/promise.cxx
+++ b/src/core/promise.cxx
@@ -181,7 +181,7 @@ constexpr auto final_suspend(frame_t<Context> *frame) noexcept -> coro<> {
 
   switch (kind) {
     case category::root:
-      std::unreachable();
+      LF_UNREACHABLE(); // Handled above
     case category::call:
       return parent->handle();
     case category::fork:
@@ -199,8 +199,6 @@ constexpr auto final_suspend(frame_t<Context> *frame) noexcept -> coro<> {
       // TODO: benchmark if this split/noinline regresses other in stealing context
       return final_suspend_continue(context, parent);
   }
-
-  std::unreachable();
 }
 
 struct final_awaitable : std::suspend_always {

--- a/src/core/promise.cxx
+++ b/src/core/promise.cxx
@@ -224,6 +224,8 @@ constexpr void stash_current_exception(frame_type<Checkpoint> *frame) noexcept {
     LF_ASSUME(exception); // Should have been called from inside a catch block
 
     // TODO: make sure exceptions are cancel-safe (I think now cancellation can leak)
+    //
+    // TODO: allocator aware -> ideally no allocation here?
 
     frame->except = new frame_type<Checkpoint>::except_type{
         .stashed = frame->parent,
@@ -294,10 +296,31 @@ struct awaitable : std::suspend_always {
 
 // =============== Join =============== //
 
+/**
+ * @brief Pull an exception out of a frame and clean-up the union/allocation.
+ */
+template <typename Checkpoint>
+constexpr auto extract_exception(frame_type<Checkpoint> *frame) noexcept -> std::exception_ptr {
+
+  LF_ASSUME(frame->exception_bit); // Should only be called if an exception was thrown.
+
+  // Local copy
+  typename frame_type<Checkpoint>::except_type except = std::move(*frame->except);
+
+  LF_ASSUME(except.exception); // Should have been set by stash_current_exception
+
+  // Clean-up exception state
+  delete frame->except;
+  // Switch union's active member
+  frame->parent = except.stashed;
+  // Reset
+  frame->exception_bit = 0;
+
+  return std::move(except.exception);
+}
+
 template <worker_context Context>
 struct join_awaitable {
-
-  using except_type = frame_t<Context>::except_type;
 
   frame_t<Context> *frame;
 
@@ -390,16 +413,8 @@ struct join_awaitable {
   }
 
   [[noreturn]]
-  constexpr auto rethrow_exception(this join_awaitable self) -> void {
-    // Local copy
-    except_type except = std::move(*self.frame->except);
-
-    // Clean-up exception state
-    delete self.frame->except;
-    self.frame->parent = except.stashed;
-    self.frame->exception_bit = 0;
-
-    std::rethrow_exception(std::move(except.exception));
+  constexpr void rethrow_exception(this join_awaitable self) {
+    std::rethrow_exception(extract_exception(self.frame));
   }
 
   constexpr void await_resume(this join_awaitable self) {

--- a/src/core/receiver.cxx
+++ b/src/core/receiver.cxx
@@ -1,5 +1,6 @@
 
 module;
+#include "libfork/__impl/assume.hpp"
 #include "libfork/__impl/exception.hpp"
 export module libfork.core:receiver;
 
@@ -62,16 +63,21 @@ class receiver {
   }
 
   [[nodiscard]]
-  auto get() -> T {
+  auto get() && -> T {
 
     wait();
 
-    if (m_state->m_exception) {
-      std::rethrow_exception(m_state->m_exception);
+    // State will be cleaned up on unwind
+    std::shared_ptr state = std::move(m_state);
+
+    LF_ASSUME(state != nullptr);
+
+    if (state->m_exception) {
+      std::rethrow_exception(state->m_exception);
     }
 
     if constexpr (!std::is_void_v<T>) {
-      return std::move(m_state->m_return_value);
+      return std::move(state->m_return_value);
     }
   }
 

--- a/src/core/receiver.cxx
+++ b/src/core/receiver.cxx
@@ -23,6 +23,7 @@ struct receiver_state {
 
   [[no_unique_address]]
   std::conditional_t<std::is_void_v<T>, empty, T> m_return_value;
+  std::exception_ptr m_exception;
   std::atomic_flag m_ready;
 };
 

--- a/src/core/receiver.cxx
+++ b/src/core/receiver.cxx
@@ -1,0 +1,81 @@
+
+module;
+#include "libfork/__impl/exception.hpp"
+export module libfork.core:receiver;
+
+import std;
+
+import :utility;
+
+namespace lf {
+
+export struct broken_receiver_error final : std::exception {
+  [[nodiscard]]
+  auto what() const noexcept -> const char * override {
+    return "Receiver is in invalid state";
+  }
+};
+
+template <typename T>
+struct receiver_state {
+
+  struct empty {};
+
+  [[no_unique_address]]
+  std::conditional_t<std::is_void_v<T>, empty, T> m_return_value;
+  std::atomic_flag m_ready;
+};
+
+template <typename T>
+class receiver {
+
+  using state_type = receiver_state<T>;
+
+ public:
+  constexpr receiver(key_t, std::shared_ptr<state_type> &&state) : m_state(std::move(state)) {}
+  constexpr receiver(receiver &&) noexcept = default;
+  constexpr auto operator=(receiver &&) noexcept -> receiver & = default;
+
+  // Move only
+  constexpr receiver(const receiver &) = delete;
+  constexpr auto operator=(const receiver &) -> receiver & = delete;
+
+  [[nodiscard]]
+  constexpr auto valid() const noexcept -> bool {
+    return m_state != nullptr;
+  }
+
+  [[nodiscard]]
+  auto ready() const -> bool {
+    if (!valid()) {
+      LF_THROW(broken_receiver_error{});
+    }
+    return m_state->m_ready.test();
+  }
+
+  void wait() const {
+    if (!valid()) {
+      LF_THROW(broken_receiver_error{});
+    }
+    m_state->m_ready.wait(false);
+  }
+
+  [[nodiscard]]
+  auto get() -> T {
+
+    wait();
+
+    if (m_state->m_exception) {
+      std::rethrow_exception(m_state->m_exception);
+    }
+
+    if constexpr (!std::is_void_v<T>) {
+      return std::move(m_state->m_return_value);
+    }
+  }
+
+ private:
+  std::shared_ptr<state_type> m_state;
+};
+
+} // namespace lf

--- a/src/core/receiver.cxx
+++ b/src/core/receiver.cxx
@@ -12,7 +12,7 @@ namespace lf {
 
 export struct broken_receiver_error final : std::exception {
   [[nodiscard]]
-  auto what() const noexcept -> const char * override {
+  constexpr auto what() const noexcept -> const char * override {
     return "Receiver is in invalid state";
   }
 };
@@ -48,14 +48,14 @@ class receiver {
   }
 
   [[nodiscard]]
-  auto ready() const -> bool {
+  constexpr auto ready() const -> bool {
     if (!valid()) {
       LF_THROW(broken_receiver_error{});
     }
     return m_state->m_ready.test();
   }
 
-  void wait() const {
+  constexpr void wait() const {
     if (!valid()) {
       LF_THROW(broken_receiver_error{});
     }
@@ -63,7 +63,7 @@ class receiver {
   }
 
   [[nodiscard]]
-  auto get() && -> T {
+  constexpr auto get() && -> T {
 
     wait();
 

--- a/src/core/receiver.cxx
+++ b/src/core/receiver.cxx
@@ -68,7 +68,7 @@ class receiver {
     wait();
 
     // State will be cleaned up on unwind
-    std::shared_ptr state = std::move(m_state);
+    std::shared_ptr state = std::exchange(m_state, nullptr);
 
     LF_ASSUME(state != nullptr);
 

--- a/src/core/root.cxx
+++ b/src/core/root.cxx
@@ -1,0 +1,29 @@
+module;
+#include "libfork/__impl/assume.hpp"
+export module libfork.core:root;
+
+import std;
+
+namespace lf {
+
+// TODO: allocator aware!
+
+struct root_task {
+  struct promise_type {
+
+    constexpr auto get_return_object() noexcept -> root_task { return {}; }
+
+    constexpr static auto initial_suspend() noexcept -> std::suspend_always { return {}; }
+
+    constexpr static auto final_suspend() noexcept -> std::suspend_always { return {}; }
+
+    [[noreturn]]
+    constexpr void unhandled_exception() noexcept {
+      LF_ASSUME(false);
+    }
+  };
+
+  promise_type *m_promise;
+};
+
+} // namespace lf

--- a/src/core/root.cxx
+++ b/src/core/root.cxx
@@ -103,7 +103,7 @@ auto package_as_root(std::shared_ptr<receiver_state<R>> recv, Fn fn, Args... arg
     child->return_address = std::addressof(recv->m_return_value);
   }
 
-  // Begin normal execution of the child task, it will clean itself
+  // Begin normal executio of the child task, it will clean itself
   // up (i.e. .destroy()) at the final suspend
   co_await &child->frame;
 

--- a/src/core/root.cxx
+++ b/src/core/root.cxx
@@ -4,14 +4,18 @@ export module libfork.core:root;
 
 import std;
 
+import :frame;
+import :promise;
+
 namespace lf {
 
 // TODO: allocator aware!
 
+template <typename Checkpoint>
 struct root_task {
   struct promise_type {
 
-    constexpr auto get_return_object() noexcept -> root_task { return {}; }
+    constexpr auto get_return_object() noexcept -> root_task { return {.promise = this}; }
 
     constexpr static auto initial_suspend() noexcept -> std::suspend_always { return {}; }
 
@@ -19,11 +23,15 @@ struct root_task {
 
     [[noreturn]]
     constexpr void unhandled_exception() noexcept {
-      LF_ASSUME(false);
+      stash_current_exception(frame);
     }
+
+    constexpr static void return_void() noexcept {}
+
+    frame_type<Checkpoint> frame{Checkpoint{}};
   };
 
-  promise_type *m_promise;
+  promise_type *promise;
 };
 
 } // namespace lf

--- a/src/core/root.cxx
+++ b/src/core/root.cxx
@@ -80,48 +80,51 @@ auto package_as_root(std::shared_ptr<receiver_state<R>> recv, Fn fn, Args... arg
   using result_type = async_result_t<Fn, Context, Args...>;
   using promise_type = promise_type<result_type, Context>;
 
+  promise_type *child = nullptr;
+
   LF_TRY {
     // Potentially throwing
-    promise_type *child = get(key(), ctx_invoke_t<Context>{}(std::move(fn), std::move(args)...));
-
-    LF_ASSUME(child != nullptr);
-
-    // TODO: cancellation
-
-    child->frame.parent.frame = root;
-    child->frame.cancel = nullptr;
-
-    LF_ASSUME(child->frame.kind == category::call);
-
-    if constexpr (!std::is_void_v<async_result_t<Fn, Context, Args...>>) {
-      child->return_address = std::addressof(recv->m_return_value);
-    }
-
-    // Begin normal executio of the child task, it will clean itself
-    // up (i.e. .destroy()) at the final suspend
-    co_await &child->frame;
-
-    // Now we have been resumed the child is done, it could have completed via:
-    //
-    // - Normal return
-    // - Exception
-    // - Cancellation
-
-    if constexpr (LF_COMPILER_EXCEPTIONS) {
-      if (root->exception_bit) {
-        // The child threw an exception, propagate it to the receiver.
-        recv->m_exception = extract_exception(root);
-      }
-    }
+    child = get(key(), ctx_invoke_t<Context>{}(std::move(fn), std::move(args)...));
   } LF_CATCH_ALL {
     recv->m_exception = std::current_exception();
+    goto cleanup;
   }
 
+  LF_ASSUME(child != nullptr);
+
+  // TODO: cancellation
+
+  child->frame.parent.frame = root;
+  child->frame.cancel = nullptr;
+
+  LF_ASSUME(child->frame.kind == category::call);
+
+  if constexpr (!std::is_void_v<async_result_t<Fn, Context, Args...>>) {
+    child->return_address = std::addressof(recv->m_return_value);
+  }
+
+  // Begin normal executio of the child task, it will clean itself
+  // up (i.e. .destroy()) at the final suspend
+  co_await &child->frame;
+
+  // Now we have been resumed the child is done, it could have completed via:
+  //
+  // - Normal return
+  // - Exception
+  // - Cancellation
+
+  if constexpr (LF_COMPILER_EXCEPTIONS) {
+    if (root->exception_bit) {
+      // The child threw an exception, propagate it to the receiver.
+      recv->m_exception = extract_exception(root);
+    }
+  }
+
+cleanup:
   // Now to that which we would otherwise do at a final suspend.
   // Notify the receiver that the task is done.
   recv->m_ready.test_and_set();
   recv->m_ready.notify_one();
-
   co_return;
 }
 

--- a/src/core/root.cxx
+++ b/src/core/root.cxx
@@ -104,7 +104,7 @@ root_pkg(std::shared_ptr<receiver_state<R>> recv, Fn fn, Args... args) -> root_t
     child->return_address = std::addressof(recv->m_return_value);
   }
 
-  // Begin normal executio of the child task, it will clean itself
+  // Begin normal execution of the child task, it will clean itself
   // up (i.e. .destroy()) at the final suspend
   co_await &child->frame;
 

--- a/src/core/root.cxx
+++ b/src/core/root.cxx
@@ -103,7 +103,7 @@ auto package_as_root(std::shared_ptr<receiver_state<R>> recv, Fn fn, Args... arg
     child->return_address = std::addressof(recv->m_return_value);
   }
 
-  // Begin normal executio of the child task, it will clean itself
+  // Begin normal execution of the child task, it will clean itself
   // up (i.e. .destroy()) at the final suspend
   co_await &child->frame;
 

--- a/src/core/root.cxx
+++ b/src/core/root.cxx
@@ -1,11 +1,13 @@
 module;
 #include "libfork/__impl/assume.hpp"
+#include "libfork/__impl/exception.hpp"
 export module libfork.core:root;
 
 import std;
 
 import :frame;
 import :promise;
+import :receiver;
 
 namespace lf {
 
@@ -52,11 +54,75 @@ struct root_task {
 
     [[noreturn]]
     constexpr void unhandled_exception() noexcept {
+      // Any exceptions escaping the root task are a bug.
       LF_UNREACHABLE();
     }
   };
 
   promise_type *promise;
 };
+
+template <worker_context Context, typename R, typename Fn, typename... Args>
+  requires async_invocable_to<Fn, R, Context, Args...>
+auto package_as_root(std::shared_ptr<receiver_state<R>> recv, Fn fn, Args... args)
+    -> root_task<checkpoint_t<Context>> {
+
+  // This should be resumed on a valid context.
+  LF_ASSUME(thread_context<Context> != nullptr);
+
+  using checkpoint = checkpoint_t<Context>;
+
+  // This is a pointer to the current root_task's frame
+  frame_type<checkpoint> *root = not_null(co_await get_frame_t{});
+
+  // Now we do a manual "call" invocation.
+
+  using result_type = async_result_t<Fn, Context, Args...>;
+  using promise_type = promise_type<result_type, Context>;
+
+  LF_TRY {
+    // Potentially throwing
+    promise_type *child = get(key(), ctx_invoke_t<Context>{}(std::move(fn), std::move(args)...));
+
+    LF_ASSUME(child != nullptr);
+
+    // TODO: cancellation
+
+    child->frame.parent.frame = root;
+    child->frame.cancel = nullptr;
+
+    LF_ASSUME(child->frame.kind == category::call);
+
+    if constexpr (!std::is_void_v<async_result_t<Fn, Context, Args...>>) {
+      child->return_address = std::addressof(recv->m_return_value);
+    }
+
+    // Begin normal executio of the child task, it will clean itself
+    // up (i.e. .destroy()) at the final suspend
+    co_await &child->frame;
+
+    // Now we have been resumed the child is done, it could have completed via:
+    //
+    // - Normal return
+    // - Exception
+    // - Cancellation
+
+    if constexpr (LF_COMPILER_EXCEPTIONS) {
+      if (root->exception_bit) {
+        // The child threw an exception, propagate it to the receiver.
+        recv->m_exception = extract_exception(root);
+      }
+    }
+  } LF_CATCH_ALL {
+    recv->m_exception = std::current_exception();
+  }
+
+  // Now to that which we would otherwise do at a final suspend.
+  // Notify the receiver that the task is done.
+  recv->m_ready.test_and_set();
+  recv->m_ready.notify_one();
+
+  co_return;
+}
 
 } // namespace lf

--- a/src/core/root.cxx
+++ b/src/core/root.cxx
@@ -11,24 +11,35 @@ namespace lf {
 
 // TODO: allocator aware!
 
+struct get_frame_t {};
+
 template <typename Checkpoint>
 struct root_task {
   struct promise_type {
+
+    frame_type<Checkpoint> frame{Checkpoint{}};
+
+    struct frame_awaitable : std::suspend_never {
+
+      frame_type<Checkpoint> *frame;
+
+      auto await_resume() const noexcept -> frame_type<Checkpoint> * { return frame; }
+    };
+
+    constexpr auto await_transform(get_frame_t) noexcept -> frame_awaitable { return {.frame = &frame}; }
 
     constexpr auto get_return_object() noexcept -> root_task { return {.promise = this}; }
 
     constexpr static auto initial_suspend() noexcept -> std::suspend_always { return {}; }
 
-    constexpr static auto final_suspend() noexcept -> std::suspend_always { return {}; }
-
-    [[noreturn]]
-    constexpr void unhandled_exception() noexcept {
-      stash_current_exception(frame);
-    }
+    constexpr static auto final_suspend() noexcept -> std::suspend_never { return {}; }
 
     constexpr static void return_void() noexcept {}
 
-    frame_type<Checkpoint> frame{Checkpoint{}};
+    [[noreturn]]
+    constexpr void unhandled_exception() noexcept {
+      LF_UNREACHABLE();
+    }
   };
 
   promise_type *promise;

--- a/src/core/root.cxx
+++ b/src/core/root.cxx
@@ -20,13 +20,27 @@ struct root_task {
     frame_type<Checkpoint> frame{Checkpoint{}};
 
     struct frame_awaitable : std::suspend_never {
-
       frame_type<Checkpoint> *frame;
-
-      auto await_resume() const noexcept -> frame_type<Checkpoint> * { return frame; }
+      [[nodiscard]]
+      constexpr auto await_resume() const noexcept -> frame_type<Checkpoint> * {
+        return frame;
+      }
     };
 
-    constexpr auto await_transform(get_frame_t) noexcept -> frame_awaitable { return {.frame = &frame}; }
+    constexpr auto await_transform([[maybe_unused]] get_frame_t tag) noexcept -> frame_awaitable {
+      return {.frame = &frame};
+    }
+
+    struct call_awaitable : std::suspend_always {
+      frame_type<Checkpoint> *child;
+      constexpr auto await_suspend([[maybe_unused]] coro<promise_type> root) const noexcept -> coro<> {
+        return child->handle();
+      }
+    };
+
+    constexpr auto await_transform(frame_type<Checkpoint> *child) noexcept -> call_awaitable {
+      return {.child = child};
+    }
 
     constexpr auto get_return_object() noexcept -> root_task { return {.promise = this}; }
 

--- a/src/core/root.cxx
+++ b/src/core/root.cxx
@@ -64,8 +64,9 @@ struct root_task {
 
 template <worker_context Context, typename R, typename Fn, typename... Args>
   requires async_invocable_to<Fn, R, Context, Args...>
-auto package_as_root(std::shared_ptr<receiver_state<R>> recv, Fn fn, Args... args)
-    -> root_task<checkpoint_t<Context>> {
+[[nodiscard]]
+auto //
+root_pkg(std::shared_ptr<receiver_state<R>> recv, Fn fn, Args... args) -> root_task<checkpoint_t<Context>> {
 
   // This should be resumed on a valid context.
   LF_ASSUME(thread_context<Context> != nullptr);

--- a/src/core/schedule.cxx
+++ b/src/core/schedule.cxx
@@ -26,52 +26,6 @@ export struct schedule_error : std::runtime_error {
   using std::runtime_error::runtime_error;
 };
 
-template <typename Context, typename State, typename Fn, typename... Args>
-auto package(std::shared_ptr<State> recv, Fn fn, Args... args) -> root_task<checkpoint_t<Context>> {
-
-  // This should be resumed on a valid context.
-  LF_ASSUME(thread_context<Context> != nullptr);
-
-  LF_TRY {
-    using checkpoint = checkpoint_t<Context>;
-
-    // This is a pointer to the current root_task's frame
-    frame_type<checkpoint> *root = co_await get_frame_t{};
-
-    // Now we do a manual "call" invocation.
-
-    using result_type = async_result_t<Fn, Context, Args...>;
-    using promise_type = promise_type<result_type, Context>;
-
-    // This is a pointer to the promise
-    promise_type *child = get(key(), ctx_invoke_t<Context>{}(std::move(fn), std::move(args)...));
-
-    // TODO: cancellation
-
-    child->frame.parent.frame = root;
-    child->frame.cancel = nullptr;
-
-    LF_ASSUME(child->frame.kind == category::call);
-
-    if constexpr (!std::is_void_v<async_result_t<Fn, Context, Args...>>) {
-      child->return_address = std::addressof(recv->m_return_value);
-    }
-
-    co_await &child->frame;
-
-  } LF_CATCH_ALL {
-    // TODO:
-  }
-
-  // Now to that which we would otherwise do at a final suspend.
-
-  // Notify the receiver that the task is done.
-  recv->m_ready.test_and_set();
-  recv->m_ready.notify_one();
-
-  co_return;
-}
-
 template <typename T>
 concept decay_copyable = std::convertible_to<T, std::decay_t<T>>;
 
@@ -105,13 +59,16 @@ schedule2(Sch &&sch, Fn &&fn, Args &&...args) -> schedule_result_t<Fn, context_t
     LF_THROW(schedule_error{"Schedule called from within a worker thread!"});
   }
 
+  // TODO: allocator aware new
   std::shared_ptr state = std::make_shared<schedule_state_t<Fn, context_type, Args...>>();
 
   // TODO: clean up block if exception
   // TODO: make sure we're cancel safe
 
   // package has shared ownership of the state.
-  root_task task = package<context_type>(state, std::forward<Fn>(fn), std::forward<Args>(args)...);
+  root_task task = package_as_root<context_type>(state, std::forward<Fn>(fn), std::forward<Args>(args)...);
+
+  LF_ASSUME(task.promise != nullptr);
 
   LF_TRY {
     sch.post(sched_handle<context_type>{key(), &task.promise->frame});

--- a/src/core/schedule.cxx
+++ b/src/core/schedule.cxx
@@ -11,6 +11,8 @@ import :frame;
 import :thread_locals;
 import :promise;
 import :root;
+import :handles;
+import :utility;
 
 namespace lf {
 
@@ -94,21 +96,32 @@ using checkpoint_for_t = checkpoint_t<stack_t<Context>>;
 
 template <typename Context, typename State, typename Fn, typename... Args>
 auto package(std::shared_ptr<State> recv, Fn fn, Args... args) -> root_task<checkpoint_for_t<Context>> {
-  //
-  // auto *promise = get(key(), ctx_invoke_t<Context>{}(std::move(fn), std::move(args)...));
+  LF_TRY {
+    // This should be resumed on a valid context.
+    LF_ASSUME(thread_context<Context> != nullptr);
 
-  // // TODO: expose cancellable?
-  // promise->frame.parent.block = root_block.get();
-  // promise->frame.cancel = nullptr;
-  // promise->frame.stack_ckpt = get_stack<Context>().checkpoint();
-  // promise->frame.kind = lf::category::root;
+    // This is a pointer to the current root_task's frame
+    auto *frame = co_await get_frame_t{};
 
-  // if constexpr (!std::is_void_v<result_type>) {
-  //   promise->return_address = &root_block->return_value;
-  // }
+    //
+    // auto *promise = get(key(), ctx_invoke_t<Context>{}(std::move(fn), std::move(args)...));
 
-  // promise->handle().resume();
-  // co_return;
+    // // TODO: expose cancellable?
+    // promise->frame.parent.block = root_block.get();
+    // promise->frame.cancel = nullptr;
+    // promise->frame.stack_ckpt = get_stack<Context>().checkpoint();
+    // promise->frame.kind = lf::category::root;
+
+    // if constexpr (!std::is_void_v<result_type>) {
+    //   promise->return_address = &root_block->return_value;
+    // }
+
+    // promise->handle().resume();
+
+    co_return;
+  } LF_CATCH_ALL {
+    // TODO:
+  };
 }
 
 template <typename T>
@@ -134,7 +147,7 @@ using schedule_result_t =
 
 export template <scheduler Sch, decay_copyable Fn, decay_copyable... Args>
   requires schedulable<Fn, context_t<Sch>, Args...>
-constexpr auto schedule2(Sch &&sch, Fn &&fn, Args &&...args) noexcept -> auto {
+constexpr auto schedule2(Sch &&sch, Fn &&fn, Args &&...args) -> auto {
 
   using context_type = context_t<Sch>;
 
@@ -153,13 +166,13 @@ constexpr auto schedule2(Sch &&sch, Fn &&fn, Args &&...args) noexcept -> auto {
   root_task task = package<context_type>(state, std::forward<Fn>(fn), std::forward<Args>(args)...);
 
   LF_TRY {
-    // TODO: publish to schedule
+    sch.post(sched_handle<context_type>{key(), &task.promise->frame});
   } LF_CATCH_ALL {
     // TODO: clean up task
     LF_RETHROW;
   }
 
-  return state;
+  // return state;
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/src/core/schedule.cxx
+++ b/src/core/schedule.cxx
@@ -13,6 +13,7 @@ import :promise;
 import :root;
 
 namespace lf {
+
 ///////////////////////////////////////////////////
 
 export template <typename T>
@@ -23,11 +24,11 @@ struct reciver_state {
 
   struct empty {};
 
-  frame_type<Checkpoint> frame;
+  // frame_type<Checkpoint> frame;
 
   [[no_unique_address]]
   std::conditional_t<std::is_void_v<T>, empty, T> m_return_value;
-  std::atomic_flag m_ready{};
+  std::atomic_flag m_ready;
 
   // TODO: destructor to clean up exception
 };
@@ -107,6 +108,7 @@ auto package(std::shared_ptr<State> recv, Fn fn, Args... args) -> root_task<chec
   // }
 
   // promise->handle().resume();
+  // co_return;
 }
 
 template <typename T>

--- a/src/core/schedule.cxx
+++ b/src/core/schedule.cxx
@@ -46,6 +46,11 @@ export template <typename Fn, typename Context, typename... Args>
   requires schedulable<Fn, Context, Args...>
 using schedule_result_t = receiver<invoke_decay_result_t<Fn, Context, Args...>>;
 
+/**
+ * @brief Schedule a function to be run on a scheduler.
+ *
+ * This function is strongly exception safe.
+ */
 export template <scheduler Sch, decay_copyable Fn, decay_copyable... Args>
   requires schedulable<Fn, context_t<Sch>, Args...>
 constexpr auto
@@ -65,13 +70,14 @@ schedule2(Sch &&sch, Fn &&fn, Args &&...args) -> schedule_result_t<Fn, context_t
   // TODO: clean up block if exception
   // TODO: make sure we're cancel safe
 
-  // package has shared ownership of the state.
+  // Package has shared ownership of the state, fine if this throws
   root_task task = package_as_root<context_type>(state, std::forward<Fn>(fn), std::forward<Args>(args)...);
 
   LF_ASSUME(task.promise != nullptr);
 
   LF_TRY {
     sch.post(sched_handle<context_type>{key(), &task.promise->frame});
+    // If ^ didn't throw then the root_task will destroy itself at the final suspend.
   } LF_CATCH_ALL {
     task.promise->frame.handle().destroy();
     LF_RETHROW;

--- a/src/core/schedule.cxx
+++ b/src/core/schedule.cxx
@@ -1,6 +1,7 @@
 module;
 #include "libfork/__impl/assume.hpp"
 #include "libfork/__impl/compiler.hpp"
+#include "libfork/__impl/exception.hpp"
 export module libfork.core:schedule;
 
 import std;
@@ -9,6 +10,7 @@ import :concepts;
 import :frame;
 import :thread_locals;
 import :promise;
+import :root;
 
 namespace lf {
 
@@ -86,53 +88,132 @@ export struct schedule_error : std::runtime_error {
   using std::runtime_error::runtime_error;
 };
 
-export template <worker_context Context, typename... Args, async_invocable<Context, Args...> Fn>
-  requires void_or_default_initializable<async_result_t<Fn, Context, Args...>>
-constexpr auto
-schedule2(Context &context, Fn &&fn, Args &&...args) noexcept -> async_result_t<Fn, Context, Args...> {
+///////////////////////////////////////////////////
+
+export template <typename T>
+concept schedulable_return = std::is_void_v<T> || std::default_initializable<T>;
+
+template <schedulable_return T>
+class reciver_state {
+
+  struct empty {};
+
+  [[no_unique_address]]
+  std::conditional_t<std::is_void_v<T>, empty, T> m_return_value;
+  std::exception_ptr m_exception;
+  std::atomic_flag m_ready{};
+};
+
+template <schedulable_return T>
+class reciver {
+ public:
+  constexpr reciver() : m_state(std::make_shared<reciver_state<T>>()) {}
+  constexpr reciver(reciver &&) noexcept = default;
+  constexpr auto operator=(reciver &&) noexcept -> reciver & = default;
+
+  // Move only
+  constexpr reciver(const reciver &) = delete;
+  constexpr auto operator=(const reciver &) -> reciver & = delete;
+
+  [[nodiscard]]
+  constexpr auto valid() const noexcept -> bool {
+    return m_state != nullptr;
+  }
+
+  [[nodiscard]]
+  auto ready() const -> bool {
+    if (!valid()) {
+      LF_THROW(schedule_error{"reciver is not valid!"});
+    }
+    return m_state->m_ready.test();
+  }
+
+  void wait() const {
+    if (!valid()) {
+      LF_THROW(schedule_error{"Invalid reciver!"});
+    }
+    m_state->m_ready.wait(false);
+  }
+
+  [[nodiscard]]
+  auto get() -> T {
+
+    wait();
+
+    if (m_state->m_exception) {
+      std::rethrow_exception(m_state->m_exception);
+    }
+
+    if constexpr (!std::is_void_v<T>) {
+      return std::move(m_state->m_return_value);
+    }
+  }
+
+ private:
+  std::shared_ptr<reciver_state<T>> m_state;
+};
+
+template <typename Context, typename R, typename Fn, typename... Args>
+auto package(block<R> *block, Fn fn, Args... args) -> root_task<checkpoint_t<stack_t<Context>>> {
+  //
+  // auto *promise = get(key(), ctx_invoke_t<Context>{}(std::move(fn), std::move(args)...));
+
+  // // TODO: expose cancellable?
+  // promise->frame.parent.block = root_block.get();
+  // promise->frame.cancel = nullptr;
+  // promise->frame.stack_ckpt = get_stack<Context>().checkpoint();
+  // promise->frame.kind = lf::category::root;
+
+  // if constexpr (!std::is_void_v<result_type>) {
+  //   promise->return_address = &root_block->return_value;
+  // }
+
+  // promise->handle().resume();
+}
+
+template <typename T>
+concept decay_copyable = std::convertible_to<T, std::decay_t<T>>;
+
+template <typename Fn, typename Context, typename... Args>
+concept schedulable_decayed =
+    async_invocable<Fn, Context, Args...> && schedulable_return<async_result_t<Fn, Context, Args...>>;
+
+export template <typename Fn, typename Context, typename... Args>
+concept schedulable = schedulable_decayed<std::decay_t<Fn>, Context, std::decay_t<Args>...>;
+
+template <typename Fn, typename Context, typename... Args>
+using block_for_t = block<async_result_t<std::decay_t<Fn>, Context, std::decay_t<Args>...>>;
+
+export template <typename Fn, typename Context, typename... Args>
+using schedule_result_t = std::unique_ptr<block_for_t<Fn, Context, Args...>, block_deleter>;
+
+export template <scheduler Sch, decay_copyable Fn, decay_copyable... Args>
+  requires schedulable<Fn, context_t<Sch>, Args...>
+constexpr auto schedule2(Sch &&sch, Fn &&fn, Args &&...args) noexcept -> auto {
+
+  using context_type = context_t<Sch>;
 
   // TODO: make sure this is exception safe and correctly qualifed
 
-  LF_ASSUME(context != nullptr);
-
-  if (thread_context<Context> != nullptr) {
+  if (thread_context<context_type> != nullptr) {
     LF_THROW(schedule_error{"Schedule called from within a worker thread!"});
   }
 
-  // This is what the async function will return.
-  using result_type = async_result_t<Fn, Context, Args...>;
-
-  auto root_block = std::unique_ptr<block<result_type>, block_deleter>{new block<result_type>{}};
+  schedule_result_t<Fn, context_type, Args...> block{new block_for_t<Fn, context_type, Args...>};
 
   // TODO: clean up block if exception
   // TODO: make sure we're cancel safe
 
-  // TODO: Before doing this we must be on a valid context.
-  LF_ASSUME(get_context<Context>() == context);
+  root_task task = package<context_type>(block.get(), std::forward<Fn>(fn), std::forward<Args>(args)...);
 
-  // The following invocation of the async function will access `context`
-
-  auto *promise = get(key(), ctx_invoke_t<Context>{}(std::forward<Fn>(fn), std::forward<Args>(args)...));
-
-  // TODO: expose cancellable?
-  promise->frame.parent.block = root_block.get();
-  promise->frame.cancel = nullptr;
-  promise->frame.stack_ckpt = get_stack<Context>().checkpoint();
-  promise->frame.kind = lf::category::root;
-
-  if constexpr (!std::is_void_v<result_type>) {
-    promise->return_address = &root_block->return_value;
+  LF_TRY {
+    // TODO: publish to schedule
+  } LF_CATCH_ALL {
+    // TODO: clean up task
+    LF_RETHROW;
   }
 
-  promise->handle().resume();
-
-  root_block->sem.acquire();
-
-  if constexpr (!std::is_void_v<result_type>) {
-    return root_block->return_value;
-  } else {
-    return;
-  }
+  return block;
 }
 
 } // namespace lf

--- a/src/core/schedule.cxx
+++ b/src/core/schedule.cxx
@@ -91,11 +91,8 @@ class reciver {
   std::shared_ptr<state_type> m_state;
 };
 
-template <typename Context>
-using checkpoint_for_t = checkpoint_t<stack_t<Context>>;
-
 template <typename Context, typename State, typename Fn, typename... Args>
-auto package(std::shared_ptr<State> recv, Fn fn, Args... args) -> root_task<checkpoint_for_t<Context>> {
+auto package(std::shared_ptr<State> recv, Fn fn, Args... args) -> root_task<checkpoint_t<Context>> {
   LF_TRY {
     // This should be resumed on a valid context.
     LF_ASSUME(thread_context<Context> != nullptr);
@@ -135,15 +132,13 @@ export template <typename Fn, typename Context, typename... Args>
 concept schedulable = schedulable_decayed<std::decay_t<Fn>, Context, std::decay_t<Args>...>;
 
 template <typename Fn, typename Context, typename... Args>
-using async_invoke_decay_result_t = async_result_t<std::decay_t<Fn>, Context, std::decay_t<Args>...>;
+using invoke_decay_result_t = async_result_t<std::decay_t<Fn>, Context, std::decay_t<Args>...>;
 
 template <typename Fn, typename Context, typename... Args>
-using schedule_state_t =
-    reciver_state<async_invoke_decay_result_t<Fn, Context, Args...>, checkpoint_for_t<Context>>;
+using schedule_state_t = reciver_state<invoke_decay_result_t<Fn, Context, Args...>, checkpoint_t<Context>>;
 
 export template <typename Fn, typename Context, typename... Args>
-using schedule_result_t =
-    reciver<async_invoke_decay_result_t<Fn, Context, Args...>, checkpoint_for_t<Context>>;
+using schedule_result_t = reciver<invoke_decay_result_t<Fn, Context, Args...>, checkpoint_t<Context>>;
 
 export template <scheduler Sch, decay_copyable Fn, decay_copyable... Args>
   requires schedulable<Fn, context_t<Sch>, Args...>

--- a/src/core/schedule.cxx
+++ b/src/core/schedule.cxx
@@ -93,32 +93,48 @@ class reciver {
 
 template <typename Context, typename State, typename Fn, typename... Args>
 auto package(std::shared_ptr<State> recv, Fn fn, Args... args) -> root_task<checkpoint_t<Context>> {
+
+  // This should be resumed on a valid context.
+  LF_ASSUME(thread_context<Context> != nullptr);
+
   LF_TRY {
-    // This should be resumed on a valid context.
-    LF_ASSUME(thread_context<Context> != nullptr);
+    using checkpoint = checkpoint_t<Context>;
 
     // This is a pointer to the current root_task's frame
-    auto *frame = co_await get_frame_t{};
+    frame_type<checkpoint> *root = co_await get_frame_t{};
 
-    //
-    // auto *promise = get(key(), ctx_invoke_t<Context>{}(std::move(fn), std::move(args)...));
+    // Now we do a manual "call" invocation.
 
-    // // TODO: expose cancellable?
-    // promise->frame.parent.block = root_block.get();
-    // promise->frame.cancel = nullptr;
-    // promise->frame.stack_ckpt = get_stack<Context>().checkpoint();
-    // promise->frame.kind = lf::category::root;
+    using result_type = async_result_t<Fn, Context, Args...>;
+    using promise_type = promise_type<result_type, Context>;
 
-    // if constexpr (!std::is_void_v<result_type>) {
-    //   promise->return_address = &root_block->return_value;
-    // }
+    // This is a pointer to the promise
+    promise_type *child = get(key(), ctx_invoke_t<Context>{}(std::move(fn), std::move(args)...));
 
-    // promise->handle().resume();
+    // TODO: cancellation
 
-    co_return;
+    child->frame.parent.frame = root;
+    child->frame.cancel = nullptr;
+
+    LF_ASSUME(child->frame.kind == category::call);
+
+    if constexpr (!std::is_void_v<async_result_t<Fn, Context, Args...>>) {
+      child->return_address = std::addressof(recv->m_return_value);
+    }
+
+    co_await &child->frame;
+
   } LF_CATCH_ALL {
     // TODO:
-  };
+  }
+
+  // Now to that which we would otherwise do at a final suspend.
+
+  // Notify the reciver that the task is done.
+  recv->m_ready.test_and_set();
+  recv->m_ready.notify_one();
+
+  co_return;
 }
 
 template <typename T>
@@ -138,11 +154,13 @@ template <typename Fn, typename Context, typename... Args>
 using schedule_state_t = reciver_state<invoke_decay_result_t<Fn, Context, Args...>, checkpoint_t<Context>>;
 
 export template <typename Fn, typename Context, typename... Args>
+  requires schedulable<Fn, Context, Args...>
 using schedule_result_t = reciver<invoke_decay_result_t<Fn, Context, Args...>, checkpoint_t<Context>>;
 
 export template <scheduler Sch, decay_copyable Fn, decay_copyable... Args>
   requires schedulable<Fn, context_t<Sch>, Args...>
-constexpr auto schedule2(Sch &&sch, Fn &&fn, Args &&...args) -> auto {
+constexpr auto
+schedule2(Sch &&sch, Fn &&fn, Args &&...args) -> schedule_result_t<Fn, context_t<Sch>, Args...> {
 
   using context_type = context_t<Sch>;
 
@@ -163,11 +181,11 @@ constexpr auto schedule2(Sch &&sch, Fn &&fn, Args &&...args) -> auto {
   LF_TRY {
     sch.post(sched_handle<context_type>{key(), &task.promise->frame});
   } LF_CATCH_ALL {
-    // TODO: clean up task
+    task.promise->frame.handle().destroy();
     LF_RETHROW;
   }
 
-  // return state;
+  return {key(), std::move(state)};
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/src/core/schedule.cxx
+++ b/src/core/schedule.cxx
@@ -13,6 +13,7 @@ import :promise;
 import :root;
 import :handles;
 import :utility;
+import :receiver;
 
 namespace lf {
 
@@ -21,74 +22,8 @@ namespace lf {
 export template <typename T>
 concept schedulable_return = std::is_void_v<T> || std::default_initializable<T>;
 
-template <schedulable_return T, typename Checkpoint>
-struct receiver_state {
-
-  struct empty {};
-
-  // frame_type<Checkpoint> frame;
-
-  [[no_unique_address]]
-  std::conditional_t<std::is_void_v<T>, empty, T> m_return_value;
-  std::atomic_flag m_ready;
-
-  // TODO: destructor to clean up exception
-};
-
 export struct schedule_error : std::runtime_error {
   using std::runtime_error::runtime_error;
-};
-
-template <schedulable_return T, typename Checkpoint>
-class receiver {
-
-  using state_type = receiver_state<T, Checkpoint>;
-
- public:
-  constexpr receiver(key_t, std::shared_ptr<state_type> &&state) : m_state(std::move(state)) {}
-  constexpr receiver(receiver &&) noexcept = default;
-  constexpr auto operator=(receiver &&) noexcept -> receiver & = default;
-
-  // Move only
-  constexpr receiver(const receiver &) = delete;
-  constexpr auto operator=(const receiver &) -> receiver & = delete;
-
-  [[nodiscard]]
-  constexpr auto valid() const noexcept -> bool {
-    return m_state != nullptr;
-  }
-
-  [[nodiscard]]
-  auto ready() const -> bool {
-    if (!valid()) {
-      LF_THROW(schedule_error{"receiver is not valid!"});
-    }
-    return m_state->m_ready.test();
-  }
-
-  void wait() const {
-    if (!valid()) {
-      LF_THROW(schedule_error{"Invalid receiver!"});
-    }
-    m_state->m_ready.wait(false);
-  }
-
-  [[nodiscard]]
-  auto get() -> T {
-
-    wait();
-
-    if (m_state->m_exception) {
-      std::rethrow_exception(m_state->m_exception);
-    }
-
-    if constexpr (!std::is_void_v<T>) {
-      return std::move(m_state->m_return_value);
-    }
-  }
-
- private:
-  std::shared_ptr<state_type> m_state;
 };
 
 template <typename Context, typename State, typename Fn, typename... Args>
@@ -151,11 +86,11 @@ template <typename Fn, typename Context, typename... Args>
 using invoke_decay_result_t = async_result_t<std::decay_t<Fn>, Context, std::decay_t<Args>...>;
 
 template <typename Fn, typename Context, typename... Args>
-using schedule_state_t = receiver_state<invoke_decay_result_t<Fn, Context, Args...>, checkpoint_t<Context>>;
+using schedule_state_t = receiver_state<invoke_decay_result_t<Fn, Context, Args...>>;
 
 export template <typename Fn, typename Context, typename... Args>
   requires schedulable<Fn, Context, Args...>
-using schedule_result_t = receiver<invoke_decay_result_t<Fn, Context, Args...>, checkpoint_t<Context>>;
+using schedule_result_t = receiver<invoke_decay_result_t<Fn, Context, Args...>>;
 
 export template <scheduler Sch, decay_copyable Fn, decay_copyable... Args>
   requires schedulable<Fn, context_t<Sch>, Args...>

--- a/src/core/schedule.cxx
+++ b/src/core/schedule.cxx
@@ -71,7 +71,7 @@ schedule2(Sch &&sch, Fn &&fn, Args &&...args) -> schedule_result_t<Fn, context_t
   // TODO: make sure we're cancel safe
 
   // Package has shared ownership of the state, fine if this throws
-  root_task task = package_as_root<context_type>(state, std::forward<Fn>(fn), std::forward<Args>(args)...);
+  root_task task = root_pkg<context_type>(state, std::forward<Fn>(fn), std::forward<Args>(args)...);
 
   LF_ASSUME(task.promise != nullptr);
 

--- a/src/core/schedule.cxx
+++ b/src/core/schedule.cxx
@@ -13,6 +13,174 @@ import :promise;
 import :root;
 
 namespace lf {
+///////////////////////////////////////////////////
+
+export template <typename T>
+concept schedulable_return = std::is_void_v<T> || std::default_initializable<T>;
+
+template <schedulable_return T, typename Checkpoint>
+struct reciver_state {
+
+  struct empty {};
+
+  frame_type<Checkpoint> frame;
+
+  [[no_unique_address]]
+  std::conditional_t<std::is_void_v<T>, empty, T> m_return_value;
+  std::atomic_flag m_ready{};
+
+  // TODO: destructor to clean up exception
+};
+
+export struct schedule_error : std::runtime_error {
+  using std::runtime_error::runtime_error;
+};
+
+template <schedulable_return T, typename Checkpoint>
+class reciver {
+
+  using state_type = reciver_state<T, Checkpoint>;
+
+ public:
+  constexpr reciver(key_t, std::shared_ptr<state_type> &&state) : m_state(std::move(state)) {}
+  constexpr reciver(reciver &&) noexcept = default;
+  constexpr auto operator=(reciver &&) noexcept -> reciver & = default;
+
+  // Move only
+  constexpr reciver(const reciver &) = delete;
+  constexpr auto operator=(const reciver &) -> reciver & = delete;
+
+  [[nodiscard]]
+  constexpr auto valid() const noexcept -> bool {
+    return m_state != nullptr;
+  }
+
+  [[nodiscard]]
+  auto ready() const -> bool {
+    if (!valid()) {
+      LF_THROW(schedule_error{"reciver is not valid!"});
+    }
+    return m_state->m_ready.test();
+  }
+
+  void wait() const {
+    if (!valid()) {
+      LF_THROW(schedule_error{"Invalid reciver!"});
+    }
+    m_state->m_ready.wait(false);
+  }
+
+  [[nodiscard]]
+  auto get() -> T {
+
+    wait();
+
+    if (m_state->m_exception) {
+      std::rethrow_exception(m_state->m_exception);
+    }
+
+    if constexpr (!std::is_void_v<T>) {
+      return std::move(m_state->m_return_value);
+    }
+  }
+
+ private:
+  std::shared_ptr<state_type> m_state;
+};
+
+template <typename Context>
+using checkpoint_for_t = checkpoint_t<stack_t<Context>>;
+
+template <typename Context, typename State, typename Fn, typename... Args>
+auto package(std::shared_ptr<State> recv, Fn fn, Args... args) -> root_task<checkpoint_for_t<Context>> {
+  //
+  // auto *promise = get(key(), ctx_invoke_t<Context>{}(std::move(fn), std::move(args)...));
+
+  // // TODO: expose cancellable?
+  // promise->frame.parent.block = root_block.get();
+  // promise->frame.cancel = nullptr;
+  // promise->frame.stack_ckpt = get_stack<Context>().checkpoint();
+  // promise->frame.kind = lf::category::root;
+
+  // if constexpr (!std::is_void_v<result_type>) {
+  //   promise->return_address = &root_block->return_value;
+  // }
+
+  // promise->handle().resume();
+}
+
+template <typename T>
+concept decay_copyable = std::convertible_to<T, std::decay_t<T>>;
+
+template <typename Fn, typename Context, typename... Args>
+concept schedulable_decayed =
+    async_invocable<Fn, Context, Args...> && schedulable_return<async_result_t<Fn, Context, Args...>>;
+
+export template <typename Fn, typename Context, typename... Args>
+concept schedulable = schedulable_decayed<std::decay_t<Fn>, Context, std::decay_t<Args>...>;
+
+template <typename Fn, typename Context, typename... Args>
+using async_invoke_decay_result_t = async_result_t<std::decay_t<Fn>, Context, std::decay_t<Args>...>;
+
+template <typename Fn, typename Context, typename... Args>
+using schedule_state_t =
+    reciver_state<async_invoke_decay_result_t<Fn, Context, Args...>, checkpoint_for_t<Context>>;
+
+export template <typename Fn, typename Context, typename... Args>
+using schedule_result_t =
+    reciver<async_invoke_decay_result_t<Fn, Context, Args...>, checkpoint_for_t<Context>>;
+
+export template <scheduler Sch, decay_copyable Fn, decay_copyable... Args>
+  requires schedulable<Fn, context_t<Sch>, Args...>
+constexpr auto schedule2(Sch &&sch, Fn &&fn, Args &&...args) noexcept -> auto {
+
+  using context_type = context_t<Sch>;
+
+  // TODO: make sure this is exception safe and correctly qualifed
+
+  if (thread_context<context_type> != nullptr) {
+    LF_THROW(schedule_error{"Schedule called from within a worker thread!"});
+  }
+
+  std::shared_ptr state = std::make_shared<schedule_state_t<Fn, context_type, Args...>>();
+
+  // TODO: clean up block if exception
+  // TODO: make sure we're cancel safe
+
+  // package has shared ownership of the state.
+  root_task task = package<context_type>(state, std::forward<Fn>(fn), std::forward<Args>(args)...);
+
+  LF_TRY {
+    // TODO: publish to schedule
+  } LF_CATCH_ALL {
+    // TODO: clean up task
+    LF_RETHROW;
+  }
+
+  return state;
+}
+
+//////////////////////////////////////////////////////////////////////
+///
+///
+///
+///
+///
+///
+///
+///
+///
+///
+///
+///
+///
+///
+///
+///
+///
+///
+///
+////////////////////////////////////////////////////////////////////////
 
 // schedule(context*, fn, args...) -> heap allocated shared state this must
 // create a task, bind appropriate values + cancellation submit the task to a
@@ -82,138 +250,6 @@ schedule(Context *context, Fn &&fn, Args &&...args) noexcept -> async_result_t<F
   } else {
     return;
   }
-}
-
-export struct schedule_error : std::runtime_error {
-  using std::runtime_error::runtime_error;
-};
-
-///////////////////////////////////////////////////
-
-export template <typename T>
-concept schedulable_return = std::is_void_v<T> || std::default_initializable<T>;
-
-template <schedulable_return T>
-class reciver_state {
-
-  struct empty {};
-
-  [[no_unique_address]]
-  std::conditional_t<std::is_void_v<T>, empty, T> m_return_value;
-  std::exception_ptr m_exception;
-  std::atomic_flag m_ready{};
-};
-
-template <schedulable_return T>
-class reciver {
- public:
-  constexpr reciver() : m_state(std::make_shared<reciver_state<T>>()) {}
-  constexpr reciver(reciver &&) noexcept = default;
-  constexpr auto operator=(reciver &&) noexcept -> reciver & = default;
-
-  // Move only
-  constexpr reciver(const reciver &) = delete;
-  constexpr auto operator=(const reciver &) -> reciver & = delete;
-
-  [[nodiscard]]
-  constexpr auto valid() const noexcept -> bool {
-    return m_state != nullptr;
-  }
-
-  [[nodiscard]]
-  auto ready() const -> bool {
-    if (!valid()) {
-      LF_THROW(schedule_error{"reciver is not valid!"});
-    }
-    return m_state->m_ready.test();
-  }
-
-  void wait() const {
-    if (!valid()) {
-      LF_THROW(schedule_error{"Invalid reciver!"});
-    }
-    m_state->m_ready.wait(false);
-  }
-
-  [[nodiscard]]
-  auto get() -> T {
-
-    wait();
-
-    if (m_state->m_exception) {
-      std::rethrow_exception(m_state->m_exception);
-    }
-
-    if constexpr (!std::is_void_v<T>) {
-      return std::move(m_state->m_return_value);
-    }
-  }
-
- private:
-  std::shared_ptr<reciver_state<T>> m_state;
-};
-
-template <typename Context, typename R, typename Fn, typename... Args>
-auto package(block<R> *block, Fn fn, Args... args) -> root_task<checkpoint_t<stack_t<Context>>> {
-  //
-  // auto *promise = get(key(), ctx_invoke_t<Context>{}(std::move(fn), std::move(args)...));
-
-  // // TODO: expose cancellable?
-  // promise->frame.parent.block = root_block.get();
-  // promise->frame.cancel = nullptr;
-  // promise->frame.stack_ckpt = get_stack<Context>().checkpoint();
-  // promise->frame.kind = lf::category::root;
-
-  // if constexpr (!std::is_void_v<result_type>) {
-  //   promise->return_address = &root_block->return_value;
-  // }
-
-  // promise->handle().resume();
-}
-
-template <typename T>
-concept decay_copyable = std::convertible_to<T, std::decay_t<T>>;
-
-template <typename Fn, typename Context, typename... Args>
-concept schedulable_decayed =
-    async_invocable<Fn, Context, Args...> && schedulable_return<async_result_t<Fn, Context, Args...>>;
-
-export template <typename Fn, typename Context, typename... Args>
-concept schedulable = schedulable_decayed<std::decay_t<Fn>, Context, std::decay_t<Args>...>;
-
-template <typename Fn, typename Context, typename... Args>
-using block_for_t = block<async_result_t<std::decay_t<Fn>, Context, std::decay_t<Args>...>>;
-
-export template <typename Fn, typename Context, typename... Args>
-using schedule_result_t = std::unique_ptr<block_for_t<Fn, Context, Args...>, block_deleter>;
-
-export template <scheduler Sch, decay_copyable Fn, decay_copyable... Args>
-  requires schedulable<Fn, context_t<Sch>, Args...>
-constexpr auto schedule2(Sch &&sch, Fn &&fn, Args &&...args) noexcept -> auto {
-
-  using context_type = context_t<Sch>;
-
-  // TODO: make sure this is exception safe and correctly qualifed
-
-  if (thread_context<context_type> != nullptr) {
-    LF_THROW(schedule_error{"Schedule called from within a worker thread!"});
-  }
-
-  schedule_result_t<Fn, context_type, Args...> block{new block_for_t<Fn, context_type, Args...>};
-
-  // TODO: clean up block if exception
-  // TODO: make sure we're cancel safe
-
-  root_task task = package<context_type>(block.get(), std::forward<Fn>(fn), std::forward<Args>(args)...);
-
-  LF_TRY {
-    // TODO: publish to schedule
-  } LF_CATCH_ALL {
-    // TODO: clean up task
-    LF_RETHROW;
-  }
-
-  return block;
 }
 
 } // namespace lf

--- a/src/core/schedule.cxx
+++ b/src/core/schedule.cxx
@@ -22,7 +22,7 @@ export template <typename T>
 concept schedulable_return = std::is_void_v<T> || std::default_initializable<T>;
 
 template <schedulable_return T, typename Checkpoint>
-struct reciver_state {
+struct receiver_state {
 
   struct empty {};
 
@@ -40,18 +40,18 @@ export struct schedule_error : std::runtime_error {
 };
 
 template <schedulable_return T, typename Checkpoint>
-class reciver {
+class receiver {
 
-  using state_type = reciver_state<T, Checkpoint>;
+  using state_type = receiver_state<T, Checkpoint>;
 
  public:
-  constexpr reciver(key_t, std::shared_ptr<state_type> &&state) : m_state(std::move(state)) {}
-  constexpr reciver(reciver &&) noexcept = default;
-  constexpr auto operator=(reciver &&) noexcept -> reciver & = default;
+  constexpr receiver(key_t, std::shared_ptr<state_type> &&state) : m_state(std::move(state)) {}
+  constexpr receiver(receiver &&) noexcept = default;
+  constexpr auto operator=(receiver &&) noexcept -> receiver & = default;
 
   // Move only
-  constexpr reciver(const reciver &) = delete;
-  constexpr auto operator=(const reciver &) -> reciver & = delete;
+  constexpr receiver(const receiver &) = delete;
+  constexpr auto operator=(const receiver &) -> receiver & = delete;
 
   [[nodiscard]]
   constexpr auto valid() const noexcept -> bool {
@@ -61,14 +61,14 @@ class reciver {
   [[nodiscard]]
   auto ready() const -> bool {
     if (!valid()) {
-      LF_THROW(schedule_error{"reciver is not valid!"});
+      LF_THROW(schedule_error{"receiver is not valid!"});
     }
     return m_state->m_ready.test();
   }
 
   void wait() const {
     if (!valid()) {
-      LF_THROW(schedule_error{"Invalid reciver!"});
+      LF_THROW(schedule_error{"Invalid receiver!"});
     }
     m_state->m_ready.wait(false);
   }
@@ -130,7 +130,7 @@ auto package(std::shared_ptr<State> recv, Fn fn, Args... args) -> root_task<chec
 
   // Now to that which we would otherwise do at a final suspend.
 
-  // Notify the reciver that the task is done.
+  // Notify the receiver that the task is done.
   recv->m_ready.test_and_set();
   recv->m_ready.notify_one();
 
@@ -151,11 +151,11 @@ template <typename Fn, typename Context, typename... Args>
 using invoke_decay_result_t = async_result_t<std::decay_t<Fn>, Context, std::decay_t<Args>...>;
 
 template <typename Fn, typename Context, typename... Args>
-using schedule_state_t = reciver_state<invoke_decay_result_t<Fn, Context, Args...>, checkpoint_t<Context>>;
+using schedule_state_t = receiver_state<invoke_decay_result_t<Fn, Context, Args...>, checkpoint_t<Context>>;
 
 export template <typename Fn, typename Context, typename... Args>
   requires schedulable<Fn, Context, Args...>
-using schedule_result_t = reciver<invoke_decay_result_t<Fn, Context, Args...>, checkpoint_t<Context>>;
+using schedule_result_t = receiver<invoke_decay_result_t<Fn, Context, Args...>, checkpoint_t<Context>>;
 
 export template <scheduler Sch, decay_copyable Fn, decay_copyable... Args>
   requires schedulable<Fn, context_t<Sch>, Args...>

--- a/src/core/thread_locals.cxx
+++ b/src/core/thread_locals.cxx
@@ -15,6 +15,8 @@ constinit inline thread_local Context *thread_context = nullptr;
 
 // TODO: return a reference, rename to get_tls_*
 
+// TODO: implictaions of thread local on constexpr
+
 /**
  * @brief A getter for the current worker context, checks for null in debug.
  */

--- a/src/core/utility.cxx
+++ b/src/core/utility.cxx
@@ -41,7 +41,7 @@ constexpr auto
 not_null(T *ptr, std::source_location const loc = std::source_location::current()) noexcept -> T * {
   if (!ptr) {
 #ifdef NDEBUG
-    std::unreachable();
+    LF_UNREACHABLE();
 #else
     impl::terminate_with("Null pointer dereferenced!", loc.file_name(), safe_cast<int>(loc.line()));
 #endif

--- a/src/schedule/inline.cxx
+++ b/src/schedule/inline.cxx
@@ -1,0 +1,11 @@
+export module libfork.schedule:inline_scheduler;
+
+import std;
+
+import libfork.core;
+
+namespace lf {
+
+//
+
+} // namespace lf

--- a/src/schedule/inline.cxx
+++ b/src/schedule/inline.cxx
@@ -20,9 +20,7 @@ class inline_scheduler {
  public:
   using context_type = Context;
 
-  auto post(lf::sched_handle<Context> handle) {
-    throw std::runtime_error{"inline_scheduler does not support post!"};
-  }
+  auto post(lf::sched_handle<Context> handle) { execute(m_context, handle); }
 
  private:
   Context m_context;

--- a/src/schedule/inline.cxx
+++ b/src/schedule/inline.cxx
@@ -6,6 +6,26 @@ import libfork.core;
 
 namespace lf {
 
-//
+// TODO: think about initialization:
+// - do we need default initializable on stack/context?
+// - with allocators
+
+// TODO: Can we store the context directly in TLS?
+
+export template <worker_context Context>
+class inline_scheduler {
+
+  // TODO: how to adapt for polymorphic contexts?
+
+ public:
+  using context_type = Context;
+
+  auto post(lf::sched_handle<Context> handle) {
+    throw std::runtime_error{"inline_scheduler does not support post!"};
+  }
+
+ private:
+  Context m_context;
+};
 
 } // namespace lf

--- a/src/schedule/schedule.cxx
+++ b/src/schedule/schedule.cxx
@@ -1,3 +1,4 @@
 export module libfork.schedule;
 
 export import :dummy_context;
+export import :inline_scheduler;

--- a/test/src/promise.cpp
+++ b/test/src/promise.cpp
@@ -7,7 +7,7 @@ import libfork.schedule;
 
 TEST_CASE("Promise test", "[promise]") {
 
-  using ckpt_t = lf::checkpoint_t<lf::stack_t<lf::dummy_context>>;
+  using ckpt_t = lf::checkpoint_t<lf::dummy_context>;
   using frame_t = lf::frame_type<ckpt_t>;
 
   // Check for safe reinterpret_casts

--- a/test/src/schedule.cpp
+++ b/test/src/schedule.cpp
@@ -13,8 +13,8 @@ using lf::env;
 using lf::task;
 
 template <typename Context>
-auto void_function(env<Context>) -> task<void, Context> {
-  co_return;
+auto void_function(env<Context>) -> task<bool, Context> {
+  co_return true;
 }
 
 } // namespace
@@ -31,5 +31,5 @@ TEST_CASE("Simple schedule", "[schedule]") {
 
   REQUIRE(recv.valid());
 
-  recv.wait();
+  REQUIRE(std::move(recv).get() == true);
 }

--- a/test/src/schedule.cpp
+++ b/test/src/schedule.cpp
@@ -3,6 +3,7 @@
 import std;
 
 import libfork.core;
+import libfork.schedule;
 
 // TODO: test (we need a context...)
 
@@ -20,5 +21,11 @@ auto void_function(env<Context>) -> task<void, Context> {
 
 TEST_CASE("Simple schedule", "[schedule]") {
 
-  lf::generic_context<false, lf::stacks::geometric<>> context; //
+  using context_type = lf::generic_context<false, lf::stacks::geometric<>>;
+
+  // lf::generic_context<false, lf::stacks::geometric<>> context; //
+
+  lf::inline_scheduler<context_type> scheduler;
+
+  schedule2(scheduler, void_function<context_type>);
 }

--- a/test/src/schedule.cpp
+++ b/test/src/schedule.cpp
@@ -5,8 +5,6 @@ import std;
 import libfork.core;
 import libfork.schedule;
 
-// TODO: test (we need a context...)
-
 namespace {
 
 using lf::env;
@@ -22,8 +20,6 @@ auto void_function(env<Context>) -> task<bool, Context> {
 TEST_CASE("Simple schedule", "[schedule]") {
 
   using context_type = lf::generic_context<false, lf::stacks::geometric<>>;
-
-  // lf::generic_context<false, lf::stacks::geometric<>> context; //
 
   lf::inline_scheduler<context_type> scheduler;
 

--- a/test/src/schedule.cpp
+++ b/test/src/schedule.cpp
@@ -27,5 +27,9 @@ TEST_CASE("Simple schedule", "[schedule]") {
 
   lf::inline_scheduler<context_type> scheduler;
 
-  schedule2(scheduler, void_function<context_type>);
+  auto recv = schedule2(scheduler, void_function<context_type>);
+
+  REQUIRE(recv.valid());
+
+  recv.wait();
 }

--- a/test/src/schedule.cpp
+++ b/test/src/schedule.cpp
@@ -1,0 +1,24 @@
+#include <catch2/catch_test_macros.hpp>
+
+import std;
+
+import libfork.core;
+
+// TODO: test (we need a context...)
+
+namespace {
+
+using lf::env;
+using lf::task;
+
+template <typename Context>
+auto void_function(env<Context>) -> task<void, Context> {
+  co_return;
+}
+
+} // namespace
+
+TEST_CASE("Simple schedule", "[schedule]") {
+
+  lf::generic_context<false, lf::stacks::geometric<>> context; //
+}

--- a/test/src/schedule.cpp
+++ b/test/src/schedule.cpp
@@ -7,6 +7,8 @@ import libfork.schedule;
 
 namespace {
 
+// TODO: test exceptions
+
 using lf::env;
 using lf::task;
 


### PR DESCRIPTION
Working as separate schedule, still need to add to benchmark and remove root handling from promise

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `receiver<T>` type for managing async operation results with `ready()`, `wait()`, and `get()` methods
  * Added inline scheduler for executing scheduled tasks
  * Introduced `schedule2()` API for scheduler-based task scheduling
  * Added `execute()` function for binding and executing tasks with context

* **Refactor**
  * Restructured checkpoint and frame type system for improved composability
  * Updated scheduling system to use receiver-based result handling

* **Chores**
  * Added `LF_UNREACHABLE()` macro for enhanced control flow optimization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->