### PR TITLE
[V4] Scheduler split 3/n

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,7 @@ target_sources(libfork_libfork
       src/core/root.cxx
       src/core/execute.cxx
       src/core/receiver.cxx
+      src/core/adaptors.cxx
       # core.stacks
       src/core/stacks/geometric.cxx
       src/core/stacks/dummy.cxx

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ target_sources(libfork_libfork
       src/core/tuple.cxx
       src/core/ops.cxx
       src/core/poly_context.cxx
-      src/core/generic_context.cxx
+      src/core/mono_context.cxx
       src/core/thread_locals.cxx
       src/core/deque.cxx
       src/core/schedule.cxx

--- a/benchmark/src/libfork_benchmark/fib/lf_parts.cpp
+++ b/benchmark/src/libfork_benchmark/fib/lf_parts.cpp
@@ -105,15 +105,15 @@ struct deque_ctx {
 };
 
 template <lf::worker_stack Stack>
-struct poly_vector_ctx final : lf::basic_poly_context<Stack> {
+struct poly_vector_ctx final : lf::poly_context<Stack> {
 
-  using handle_type = lf::steal_handle<lf::basic_poly_context<Stack>>;
+  using handle_type = lf::steal_handle<lf::poly_context<Stack>>;
 
   std::vector<handle_type> work;
 
   poly_vector_ctx() { work.reserve(1024); }
 
-  void post(lf::sched_handle<lf::basic_poly_context<Stack>>) override {}
+  void post(lf::sched_handle<lf::poly_context<Stack>>) override {}
 
   void push(handle_type handle) override { work.push_back(handle); }
 
@@ -130,13 +130,13 @@ struct poly_vector_ctx final : lf::basic_poly_context<Stack> {
 };
 
 template <lf::worker_stack Stack>
-struct poly_deque_ctx final : lf::basic_poly_context<Stack> {
+struct poly_deque_ctx final : lf::poly_context<Stack> {
 
-  using handle_type = lf::steal_handle<lf::basic_poly_context<Stack>>;
+  using handle_type = lf::steal_handle<lf::poly_context<Stack>>;
 
   lf::deque<handle_type> work{64};
 
-  void post(lf::sched_handle<lf::basic_poly_context<Stack>>) override {}
+  void post(lf::sched_handle<lf::poly_context<Stack>>) override {}
 
   void push(handle_type handle) override { work.push(handle); }
 
@@ -283,14 +283,14 @@ BENCHMARK(fib<fork_call<stacks_alloc>, stacks_alloc>)
     ->Arg(fib_base);
 
 using A = poly_vector_ctx<linear_allocator>;
-using B = lf::basic_poly_context<linear_allocator>;
+using B = lf::poly_context<linear_allocator>;
 
 // Same as above but with polymorphic contexts.
 BENCHMARK(fib<fork_call<B>, A, B>)->Name("test/libfork/fib/poly_vector_ctx")->Arg(fib_test);
 BENCHMARK(fib<fork_call<B>, A, B>)->Name("base/libfork/fib/poly_vector_ctx")->Arg(fib_base);
 
 using E = poly_vector_ctx<lf::stacks::geometric<>>;
-using F = lf::basic_poly_context<lf::stacks::geometric<>>;
+using F = lf::poly_context<lf::stacks::geometric<>>;
 
 BENCHMARK(fib<fork_call<F>, E, F>)->Name("test/libfork/fib/poly_geometric_vector_ctx")->Arg(fib_test);
 BENCHMARK(fib<fork_call<F>, E, F>)->Name("base/libfork/fib/poly_geometric_vector_ctx")->Arg(fib_base);

--- a/benchmark/src/libfork_benchmark/fib/libfork.cpp
+++ b/benchmark/src/libfork_benchmark/fib/libfork.cpp
@@ -69,13 +69,13 @@ using lf::stacks::geometric;
 
 #define BENCH_ALL(...) BENCH_ONE(test, __VA_ARGS__) BENCH_ONE(base, __VA_ARGS__)
 
-template <typename Stack, template <typename, typename> typename Container>
-using real_context = generic_context<Stack, Container>;
+template <typename Stack, template <typename, typename> typename Container = std::vector>
+using real_context = generic_context<Stack>; // TODO: use container
 
 // template <typename Stack, template <typename, typename> typename Container>
 // using poly_context = generic_context<Stack>;
 
-// BENCH_ALL(inline_scheduler<real_context<geometric<>, deque>>)
+BENCH_ALL(inline_scheduler<real_context<geometric<>>>)
 
 // BENCH_ALL(inline_scheduler<real_context<geometric<>, deque>>)
 

--- a/benchmark/src/libfork_benchmark/fib/libfork.cpp
+++ b/benchmark/src/libfork_benchmark/fib/libfork.cpp
@@ -60,8 +60,8 @@ void run(benchmark::State &state) {
 } // namespace
 
 using lf::deque;
-using lf::mono_context;
 using lf::inline_scheduler;
+using lf::mono_context;
 using lf::stacks::geometric;
 
 #define BENCH_ONE(mode, ...)                                                                                 \

--- a/benchmark/src/libfork_benchmark/fib/libfork.cpp
+++ b/benchmark/src/libfork_benchmark/fib/libfork.cpp
@@ -12,29 +12,33 @@
 namespace {
 
 using lf::env;
+using lf::scheduler;
 using lf::task;
 using lf::worker_context;
+using lf::receiver;
 
-constexpr auto fib = []<worker_context Context>(this auto fib, env<Context>,
-                                                std::int64_t n) -> task<std::int64_t, Context> {
-  if (n < 2) {
-    co_return n;
+struct fib {
+  template <worker_context Context>
+  static auto operator()(env<Context>, std::int64_t n) -> task<std::int64_t, Context> {
+    if (n < 2) {
+      co_return n;
+    }
+
+    std::int64_t lhs = 0;
+    std::int64_t rhs = 0;
+
+    using scope = lf::scope<Context>;
+
+    co_await scope::fork(&rhs, fib{}, n - 2);
+    co_await scope::call(&lhs, fib{}, n - 1);
+
+    co_await lf::join();
+
+    co_return lhs + rhs;
   }
-
-  std::int64_t lhs = 0;
-  std::int64_t rhs = 0;
-
-  using scope = lf::scope<Context>;
-
-  co_await scope::fork(&rhs, fib, n - 2);
-  co_await scope::call(&lhs, fib, n - 1);
-
-  co_await lf::join();
-
-  co_return lhs + rhs;
 };
 
-template <worker_context Context>
+template <scheduler Sch>
 void run(benchmark::State &state) {
 
   std::int64_t n = state.range(0);
@@ -42,12 +46,12 @@ void run(benchmark::State &state) {
 
   state.counters["n"] = static_cast<double>(n);
 
-  Context context;
+  Sch scheduler;
 
   for (auto _ : state) {
     benchmark::DoNotOptimize(n);
-    std::int64_t return_value = 0;
-    lf::schedule(&context, fib, n);
+    receiver recv = lf::schedule2(scheduler, fib{}, n);
+    std::int64_t return_value = std::move(recv).get();
     CHECK_RESULT(return_value, expect);
     benchmark::DoNotOptimize(return_value);
   }
@@ -56,10 +60,19 @@ void run(benchmark::State &state) {
 } // namespace
 
 using lf::deque;
-// using lf::inline_context;
+using lf::inline_scheduler;
+using lf::generic_context;
 using lf::stacks::geometric;
 
-// // Minimal coroutine, bump allocated (thread-local) stack
-// BENCHMARK_TEMPLATE(run, inline_context<false,
-// geometric<>>)->Name("test/libfork/inline/nopoly/geometric")->Arg(fib_test); BENCHMARK_TEMPLATE(run,
-// inline_context<false, geometric<>>)->Name("base/libfork/inline/nopoly/geometric")->Arg(fib_base);
+#define BENCH_ONE(mode, ...) BENCHMARK_TEMPLATE(run, __VA_ARGS__)->Name(#mode "/libfork/fib/" #__VA_ARGS__)->Arg(fib_##mode);
+#define BENCH_ALL(...) BENCH_ONE(test, __VA_ARGS__) BENCH_ONE(base, __VA_ARGS__)
+
+template<typename Stack>
+using real_context = generic_context<false, Stack>;
+
+template<typename Stack>
+using poly_context = generic_context<true, Stack>;
+
+BENCH_ALL(inline_scheduler<real_context<geometric<>>>);
+
+// BENCH_ALL(inline_scheduler<poly_context<geometric<>>>);

--- a/benchmark/src/libfork_benchmark/fib/libfork.cpp
+++ b/benchmark/src/libfork_benchmark/fib/libfork.cpp
@@ -11,15 +11,9 @@
 
 namespace {
 
-using lf::env;
-using lf::receiver;
-using lf::scheduler;
-using lf::task;
-using lf::worker_context;
-
 struct fib {
-  template <worker_context Context>
-  static auto operator()(env<Context>, std::int64_t n) -> task<std::int64_t, Context> {
+  template <lf::worker_context Context>
+  static auto operator()(lf::env<Context>, std::int64_t n) -> lf::task<std::int64_t, Context> {
     if (n < 2) {
       co_return n;
     }
@@ -38,7 +32,7 @@ struct fib {
   }
 };
 
-template <scheduler Sch>
+template <lf::scheduler Sch>
 void run(benchmark::State &state) {
 
   std::int64_t n = state.range(0);
@@ -50,7 +44,7 @@ void run(benchmark::State &state) {
 
   for (auto _ : state) {
     benchmark::DoNotOptimize(n);
-    receiver recv = lf::schedule2(scheduler, fib{}, n);
+    lf::receiver recv = lf::schedule2(scheduler, fib{}, n);
     std::int64_t return_value = std::move(recv).get();
     CHECK_RESULT(return_value, expect);
     benchmark::DoNotOptimize(return_value);
@@ -59,25 +53,22 @@ void run(benchmark::State &state) {
 
 } // namespace
 
-using lf::adapt_deque;
-using lf::adapt_vector;
-using lf::deque;
-using lf::derived_poly_context;
-using lf::inline_scheduler;
-using lf::mono_context;
-
-using lf::stacks::geometric;
-
 #define BENCH_ONE(mode, ...)                                                                                 \
   BENCHMARK_TEMPLATE(run, __VA_ARGS__)->Name(#mode "/libfork/fib/" #__VA_ARGS__)->Arg(fib_##mode);
 
 #define BENCH_ALL(...) BENCH_ONE(test, __VA_ARGS__) BENCH_ONE(base, __VA_ARGS__)
 
 template <typename Stack, template <typename> typename Adaptor>
-using real_context = mono_context<Stack, Adaptor>; // TODO: use container
+using real_context = lf::mono_context<Stack, Adaptor>;
 
 template <typename Stack, template <typename> typename Adaptor>
-using poly_context = derived_poly_context<Stack, Adaptor>; // TODO: use container
+using poly_context = lf::derived_poly_context<Stack, Adaptor>;
+
+using lf::adapt_deque;
+using lf::adapt_vector;
+using lf::inline_scheduler;
+
+using lf::stacks::geometric;
 
 BENCH_ALL(inline_scheduler<real_context<geometric<>, adapt_vector>>)
 BENCH_ALL(inline_scheduler<poly_context<geometric<>, adapt_vector>>)

--- a/benchmark/src/libfork_benchmark/fib/libfork.cpp
+++ b/benchmark/src/libfork_benchmark/fib/libfork.cpp
@@ -66,14 +66,17 @@ using lf::stacks::geometric;
 
 #define BENCH_ONE(mode, ...)                                                                                 \
   BENCHMARK_TEMPLATE(run, __VA_ARGS__)->Name(#mode "/libfork/fib/" #__VA_ARGS__)->Arg(fib_##mode);
+
 #define BENCH_ALL(...) BENCH_ONE(test, __VA_ARGS__) BENCH_ONE(base, __VA_ARGS__)
 
-template <typename Stack>
+template <typename Stack, template <typename, typename> typename Container>
 using real_context = generic_context<false, Stack>;
 
-template <typename Stack>
+template <typename Stack, template <typename, typename> typename Container>
 using poly_context = generic_context<true, Stack>;
 
-BENCH_ALL(inline_scheduler<real_context<geometric<>>>)
+BENCH_ALL(inline_scheduler<real_context<geometric<>, deque>>)
+
+BENCH_ALL(inline_scheduler<real_context<geometric<>, deque>>)
 
 // BENCH_ALL(inline_scheduler<poly_context<geometric<>>>)

--- a/benchmark/src/libfork_benchmark/fib/libfork.cpp
+++ b/benchmark/src/libfork_benchmark/fib/libfork.cpp
@@ -70,13 +70,13 @@ using lf::stacks::geometric;
 #define BENCH_ALL(...) BENCH_ONE(test, __VA_ARGS__) BENCH_ONE(base, __VA_ARGS__)
 
 template <typename Stack, template <typename, typename> typename Container>
-using real_context = generic_context<false, Stack>;
+using real_context = generic_context<Stack, Container>;
 
-template <typename Stack, template <typename, typename> typename Container>
-using poly_context = generic_context<true, Stack>;
+// template <typename Stack, template <typename, typename> typename Container>
+// using poly_context = generic_context<Stack>;
 
-BENCH_ALL(inline_scheduler<real_context<geometric<>, deque>>)
+// BENCH_ALL(inline_scheduler<real_context<geometric<>, deque>>)
 
-BENCH_ALL(inline_scheduler<real_context<geometric<>, deque>>)
+// BENCH_ALL(inline_scheduler<real_context<geometric<>, deque>>)
 
 // BENCH_ALL(inline_scheduler<poly_context<geometric<>>>)

--- a/benchmark/src/libfork_benchmark/fib/libfork.cpp
+++ b/benchmark/src/libfork_benchmark/fib/libfork.cpp
@@ -12,10 +12,10 @@
 namespace {
 
 using lf::env;
+using lf::receiver;
 using lf::scheduler;
 using lf::task;
 using lf::worker_context;
-using lf::receiver;
 
 struct fib {
   template <worker_context Context>
@@ -60,19 +60,20 @@ void run(benchmark::State &state) {
 } // namespace
 
 using lf::deque;
-using lf::inline_scheduler;
 using lf::generic_context;
+using lf::inline_scheduler;
 using lf::stacks::geometric;
 
-#define BENCH_ONE(mode, ...) BENCHMARK_TEMPLATE(run, __VA_ARGS__)->Name(#mode "/libfork/fib/" #__VA_ARGS__)->Arg(fib_##mode);
+#define BENCH_ONE(mode, ...)                                                                                 \
+  BENCHMARK_TEMPLATE(run, __VA_ARGS__)->Name(#mode "/libfork/fib/" #__VA_ARGS__)->Arg(fib_##mode);
 #define BENCH_ALL(...) BENCH_ONE(test, __VA_ARGS__) BENCH_ONE(base, __VA_ARGS__)
 
-template<typename Stack>
+template <typename Stack>
 using real_context = generic_context<false, Stack>;
 
-template<typename Stack>
+template <typename Stack>
 using poly_context = generic_context<true, Stack>;
 
-BENCH_ALL(inline_scheduler<real_context<geometric<>>>);
+BENCH_ALL(inline_scheduler<real_context<geometric<>>>)
 
-// BENCH_ALL(inline_scheduler<poly_context<geometric<>>>);
+// BENCH_ALL(inline_scheduler<poly_context<geometric<>>>)

--- a/benchmark/src/libfork_benchmark/fib/libfork.cpp
+++ b/benchmark/src/libfork_benchmark/fib/libfork.cpp
@@ -59,6 +59,7 @@ void run(benchmark::State &state) {
 
 } // namespace
 
+using lf::adapt_deque;
 using lf::adapt_vector;
 using lf::deque;
 using lf::derived_poly_context;
@@ -79,7 +80,7 @@ template <typename Stack, template <typename> typename Adaptor>
 using poly_context = derived_poly_context<Stack, Adaptor>; // TODO: use container
 
 BENCH_ALL(inline_scheduler<real_context<geometric<>, adapt_vector>>)
+BENCH_ALL(inline_scheduler<poly_context<geometric<>, adapt_vector>>)
 
-// BENCH_ALL(inline_scheduler<real_context<geometric<>, deque>>)
-
-// BENCH_ALL(inline_scheduler<poly_context<geometric<>>>)
+BENCH_ALL(inline_scheduler<real_context<geometric<>, adapt_deque>>)
+BENCH_ALL(inline_scheduler<poly_context<geometric<>, adapt_deque>>)

--- a/benchmark/src/libfork_benchmark/fib/libfork.cpp
+++ b/benchmark/src/libfork_benchmark/fib/libfork.cpp
@@ -59,9 +59,12 @@ void run(benchmark::State &state) {
 
 } // namespace
 
+using lf::adapt_vector;
 using lf::deque;
+using lf::derived_poly_context;
 using lf::inline_scheduler;
 using lf::mono_context;
+
 using lf::stacks::geometric;
 
 #define BENCH_ONE(mode, ...)                                                                                 \
@@ -69,13 +72,13 @@ using lf::stacks::geometric;
 
 #define BENCH_ALL(...) BENCH_ONE(test, __VA_ARGS__) BENCH_ONE(base, __VA_ARGS__)
 
-template <typename Stack, template <typename, typename> typename Container = std::vector>
-using real_context = mono_context<Stack>; // TODO: use container
+template <typename Stack, template <typename> typename Adaptor>
+using real_context = mono_context<Stack, Adaptor>; // TODO: use container
 
-// template <typename Stack, template <typename, typename> typename Container>
-// using poly_context = mono_context<Stack>;
+template <typename Stack, template <typename> typename Adaptor>
+using poly_context = derived_poly_context<Stack, Adaptor>; // TODO: use container
 
-BENCH_ALL(inline_scheduler<real_context<geometric<>>>)
+BENCH_ALL(inline_scheduler<real_context<geometric<>, adapt_vector>>)
 
 // BENCH_ALL(inline_scheduler<real_context<geometric<>, deque>>)
 

--- a/benchmark/src/libfork_benchmark/fib/libfork.cpp
+++ b/benchmark/src/libfork_benchmark/fib/libfork.cpp
@@ -60,7 +60,7 @@ void run(benchmark::State &state) {
 } // namespace
 
 using lf::deque;
-using lf::generic_context;
+using lf::mono_context;
 using lf::inline_scheduler;
 using lf::stacks::geometric;
 
@@ -70,10 +70,10 @@ using lf::stacks::geometric;
 #define BENCH_ALL(...) BENCH_ONE(test, __VA_ARGS__) BENCH_ONE(base, __VA_ARGS__)
 
 template <typename Stack, template <typename, typename> typename Container = std::vector>
-using real_context = generic_context<Stack>; // TODO: use container
+using real_context = mono_context<Stack>; // TODO: use container
 
 // template <typename Stack, template <typename, typename> typename Container>
-// using poly_context = generic_context<Stack>;
+// using poly_context = mono_context<Stack>;
 
 BENCH_ALL(inline_scheduler<real_context<geometric<>>>)
 

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -1,0 +1,19 @@
+# Structure of libfork
+
+Libfork is organised into several modules:
+
+- `libfork`: Meta module that re-exports all public modules
+- `libfork.utils`: Independent internal utilities, not part of the public API
+- `libfork.core`: Core functionality of libfork including:
+  - Task template
+  - Task handles
+  - Concepts for context/stack/scheduler
+  - Fork/call primatives
+  - Execute primitives (for starting work)
+  - Schedule primitive (for launching work)
+  - Polymorphic context ABC
+  - \[internal\] Promise/frame
+- `libfork.batteries`: Collection of context, stack and other types
+  - The `::stacks` namespace
+- `libfork.schedulers`: Collection of schedulers
+  - Inline scheduler

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -1,6 +1,6 @@
 # Structure of libfork
 
-Libfork is organised into several modules:
+Libfork is organized into several modules:
 
 - `libfork`: Meta module that re-exports all public modules
 - `libfork.utils`: Independent internal utilities, not part of the public API
@@ -8,7 +8,7 @@ Libfork is organised into several modules:
   - Task template
   - Task handles
   - Concepts for context/stack/scheduler
-  - Fork/call primatives
+  - Fork/call primitives
   - Execute primitives (for starting work)
   - Schedule primitive (for launching work)
   - Polymorphic context ABC

--- a/src/core/adaptors.cxx
+++ b/src/core/adaptors.cxx
@@ -1,1 +1,27 @@
 export module libfork.core:adaptors;
+
+import :handles;
+
+namespace lf {
+
+// TODO: move stacks and contexts out of core and into substrate?
+
+export template <typename Context>
+class adapt_vector {
+ public:
+  constexpr void push(steal_handle<Context> value) { m_vector.push_back(value); }
+
+  constexpr auto pop() noexcept -> steal_handle<Context> {
+    if (!m_vector.empty()) {
+      steal_handle<Context> value = m_vector.back();
+      m_vector.pop_back();
+      return value;
+    }
+    return {};
+  }
+
+ private:
+  std::vector<steal_handle<Context>> m_vector;
+};
+
+} // namespace lf

--- a/src/core/adaptors.cxx
+++ b/src/core/adaptors.cxx
@@ -1,6 +1,7 @@
 export module libfork.core:adaptors;
 
 import :handles;
+import :deque;
 
 namespace lf {
 
@@ -22,6 +23,21 @@ class adapt_vector {
 
  private:
   std::vector<steal_handle<Context>> m_vector;
+};
+
+export template <typename Context>
+class adapt_deque {
+ public:
+  constexpr void push(steal_handle<Context> value) { m_deque.push(value); }
+
+  constexpr auto pop() noexcept -> steal_handle<Context> {
+    return m_deque.pop([] static noexcept -> steal_handle<Context> {
+      return {};
+    });
+  }
+
+ private:
+  deque<steal_handle<Context>> m_deque{1024};
 };
 
 } // namespace lf

--- a/src/core/adaptors.cxx
+++ b/src/core/adaptors.cxx
@@ -1,0 +1,1 @@
+export module libfork.core:adaptors;

--- a/src/core/concepts.cxx
+++ b/src/core/concepts.cxx
@@ -118,6 +118,9 @@ concept worker_stack = plain_object<T> && requires (T stack, std::size_t n, void
   { stack.acquire(constify(stack.checkpoint())) } noexcept -> std::same_as<void>;
 };
 
+export template <typename T>
+concept aa_worker_stack = worker_stack<T> && true; // TODO: Allocator aware stack
+
 // ==== Context
 
 export template <typename T>

--- a/src/core/concepts.cxx
+++ b/src/core/concepts.cxx
@@ -161,6 +161,15 @@ using stack_t = std::remove_reference_t<decltype(std::declval<T &>().stack())>;
 export template <worker_context T>
 using checkpoint_t = decltype(std::declval<stack_t<T> &>().checkpoint());
 
+template <typename T>
+concept has_context_typedef = requires { typename std::remove_cvref_t<T>::context_type; };
+
+template <has_context_typedef T>
+using context_t = typename std::remove_cvref_t<T>::context_type;
+
+template <typename Context>
+concept derived_worker_context = has_context_typedef<Context> && worker_context<context_t<Context>>;
+
 // ==== Scheduler
 
 /**
@@ -171,13 +180,11 @@ using checkpoint_t = decltype(std::declval<stack_t<T> &>().checkpoint());
  * - Satisfy the strong exception guarantee.
  * - Guarantee eventual execution of the task associated with `handle`.
  */
-export template <typename T>
-concept scheduler = requires (T sched, sched_handle<typename std::remove_cvref_t<T>::context_type> handle) {
-  { sched.post(handle) } -> std::same_as<void>;
-};
-
-template <scheduler Sch>
-using context_t = typename std::remove_cvref_t<Sch>::context_type;
+export template <typename Sch>
+concept scheduler =
+    has_context_typedef<Sch> && requires (Sch scheduler, sched_handle<context_t<Sch>> handle) {
+      { scheduler.post(handle) } -> std::same_as<void>;
+    };
 
 // ==== Forward-decl
 

--- a/src/core/concepts.cxx
+++ b/src/core/concepts.cxx
@@ -167,8 +167,12 @@ concept has_context_typedef = requires { typename std::remove_cvref_t<T>::contex
 template <has_context_typedef T>
 using context_t = typename std::remove_cvref_t<T>::context_type;
 
+template <typename Derived, typename Base>
+concept derived_context_from = worker_context<Base> && std::derived_from<Derived, Base>;
+
 export template <typename Context>
-concept derived_worker_context = has_context_typedef<Context> && worker_context<context_t<Context>>;
+concept derived_worker_context =
+    has_context_typedef<Context> && derived_context_from<Context, context_t<Context>>;
 
 // ==== Scheduler
 

--- a/src/core/concepts.cxx
+++ b/src/core/concepts.cxx
@@ -167,7 +167,7 @@ concept has_context_typedef = requires { typename std::remove_cvref_t<T>::contex
 template <has_context_typedef T>
 using context_t = typename std::remove_cvref_t<T>::context_type;
 
-template <typename Context>
+export template <typename Context>
 concept derived_worker_context = has_context_typedef<Context> && worker_context<context_t<Context>>;
 
 // ==== Scheduler

--- a/src/core/core.cxx
+++ b/src/core/core.cxx
@@ -26,3 +26,4 @@ export import :schedule;
 export import :root;
 export import :execute;
 export import :receiver;
+export import :adaptors;

--- a/src/core/core.cxx
+++ b/src/core/core.cxx
@@ -18,7 +18,7 @@ export import :frame;
 export import :deque;
 export import :thread_locals;
 export import :poly_context;
-export import :generic_context;
+export import :mono_context;
 export import :ops;
 export import :handles;
 export import :promise;

--- a/src/core/deque.cxx
+++ b/src/core/deque.cxx
@@ -177,11 +177,9 @@ struct return_nullopt {
  * - Rust: https://github.com/crossbeam-rs/crossbeam/blob/master/crossbeam-deque/src/deque.rs
  * - CDSC: https://dl.acm.org/doi/epdf/10.1145/2544173.2509514
  *
- * TODO: mention the allocator will be rebound (better to use atomic ref!)?
- *
  * @tparam T The type of the elements in the deque.
  */
-export template <dequeable T, allocator_of<T> Allocator = std::allocator<T>>
+export template <dequeable T, allocator_of<std::atomic<T>> Allocator = std::allocator<std::atomic<T>>>
 class deque : immovable {
  public:
   /**

--- a/src/core/deque.cxx
+++ b/src/core/deque.cxx
@@ -177,9 +177,11 @@ struct return_nullopt {
  * - Rust: https://github.com/crossbeam-rs/crossbeam/blob/master/crossbeam-deque/src/deque.rs
  * - CDSC: https://dl.acm.org/doi/epdf/10.1145/2544173.2509514
  *
+ * TODO: mention the allocator will be rebound (better to use atomic ref!)?
+ *
  * @tparam T The type of the elements in the deque.
  */
-export template <dequeable T, allocator_of<std::atomic<T>> Allocator = std::allocator<std::atomic<T>>>
+export template <dequeable T, allocator_of<T> Allocator = std::allocator<T>>
 class deque : immovable {
  public:
   /**

--- a/src/core/generic_context.cxx
+++ b/src/core/generic_context.cxx
@@ -31,9 +31,9 @@ export template <                                                   //
     worker_stack Stack,                                             //
     template <typename, typename> typename Container = vector_stack //
     >
-class generic_context final : context_base<Polymorphic, Stack> {
+class generic_context final : maybe_poly_context<Polymorphic, Stack> {
 
-  using base_type = context_base<Polymorphic, Stack>;
+  using base_type = maybe_poly_context<Polymorphic, Stack>;
 
  public:
   using context_type = std::conditional_t<Polymorphic, base_type, generic_context>;

--- a/src/core/generic_context.cxx
+++ b/src/core/generic_context.cxx
@@ -32,7 +32,7 @@ export template <                                                   //
     worker_stack Stack,                                             //
     template <typename, typename> typename Container = vector_stack //
     >
-class generic_context : public context_stack_base<Stack> {
+class generic_context : public base_context<Stack> {
 
   using sched_h = sched_handle<generic_context>;
   using steal_h = steal_handle<generic_context>;

--- a/src/core/generic_context.cxx
+++ b/src/core/generic_context.cxx
@@ -26,6 +26,8 @@ class vector_stack {
   std::vector<T, Allocator> m_vector;
 };
 
+// TODO: allow customization of post (via Container?)
+
 export template <                                                   //
     bool Polymorphic,                                               //
     worker_stack Stack,                                             //

--- a/src/core/generic_context.cxx
+++ b/src/core/generic_context.cxx
@@ -29,20 +29,15 @@ class vector_stack {
 // TODO: allow customization of post (via Container?)
 
 export template <                                                   //
-    bool Polymorphic,                                               //
     worker_stack Stack,                                             //
     template <typename, typename> typename Container = vector_stack //
     >
-class generic_context final : maybe_poly_context<Polymorphic, Stack> {
+class generic_context : public context_stack_base<Stack> {
 
-  using base_type = maybe_poly_context<Polymorphic, Stack>;
+  using sched_h = sched_handle<generic_context>;
+  using steal_h = steal_handle<generic_context>;
 
- public:
-  using context_type = std::conditional_t<Polymorphic, base_type, generic_context>;
-
- private:
-  using sched_h = sched_handle<context_type>;
-  using steal_h = steal_handle<context_type>;
+  // TODO: Move some of these type defs into the base class
 
   using allocator_type = Stack::allocator_type;
   using allocator_traits = std::allocator_traits<allocator_type>;
@@ -50,23 +45,12 @@ class generic_context final : maybe_poly_context<Polymorphic, Stack> {
   using container_type = Container<steal_h, typename allocator_traits::template rebind_alloc<steal_h>>;
 
  public:
-  /**
-   * @brief Get a view of this object as a context.
-   */
-  constexpr auto context() noexcept -> base_type & { return *this; }
-
-  using base_type::stack;
-
   constexpr void push(steal_h frame) { m_container.push(frame); }
 
   constexpr auto pop() noexcept -> steal_h { return m_container.pop(); }
 
-  // constexpr void post(sched_h frame) {}
-
   // TODO: make allocator aware
   // TODO: make generic over vector/deque
-
-  // explicit constexpr inline_context(allocator_type const &) noexcept;
 
  private:
   container_type m_container;

--- a/src/core/mono_context.cxx
+++ b/src/core/mono_context.cxx
@@ -1,4 +1,4 @@
-export module libfork.core:generic_context;
+export module libfork.core:mono_context;
 
 import std;
 
@@ -32,10 +32,10 @@ export template <                                                   //
     worker_stack Stack,                                             //
     template <typename, typename> typename Container = vector_stack //
     >
-class generic_context : public base_context<Stack> {
+class mono_context : public base_context<Stack> {
 
-  using sched_h = sched_handle<generic_context>;
-  using steal_h = steal_handle<generic_context>;
+  using sched_h = sched_handle<mono_context>;
+  using steal_h = steal_handle<mono_context>;
 
   // TODO: Move some of these type defs into the base class
 

--- a/src/core/mono_context.cxx
+++ b/src/core/mono_context.cxx
@@ -10,7 +10,7 @@ import :poly_context;
 namespace lf {
 
 template <typename Context>
-class vector_stack {
+class vector_adaptor {
  public:
   constexpr void push(steal_handle<Context> value) { m_vector.push_back(value); }
 
@@ -30,23 +30,30 @@ class vector_stack {
 // TODO: allow customization of post (via Container?)
 // TODO: allocator aware
 
-export template <                                         //
-    worker_stack Stack,                                   //
-    template <typename> typename Container = vector_stack //
+export template <                                           //
+    worker_stack Stack,                                     //
+    template <typename> typename Container = vector_adaptor //
     >
 class mono_context : public base_context<Stack> {
  public:
-  constexpr void push(steal_handle<mono_context> frame) noexcept(noexcept(m_container.push(frame))) {
+  using context_type = mono_context;
+
+  constexpr void push(steal_handle<context_type> frame) noexcept(noexcept(m_container.push(frame))) {
     m_container.push(frame);
   }
 
-  constexpr auto pop() noexcept -> steal_handle<mono_context> { return m_container.pop(); }
+  constexpr auto pop() noexcept -> steal_handle<context_type> { return m_container.pop(); }
 
-  constexpr auto
-  post(sched_handle<mono_context> handle) noexcept(noexcept(m_container.post(handle))) -> void {}
+  constexpr void post(sched_handle<context_type> handle) noexcept(noexcept(m_container.post(handle)))
+    requires requires (Container<context_type> context) {
+      { context.post(handle) } -> std::same_as<void>;
+    }
+  {
+    m_container.post(handle);
+  }
 
  private:
-  Container<mono_context> m_container;
+  Container<context_type> m_container;
 };
 
 } // namespace lf

--- a/src/core/mono_context.cxx
+++ b/src/core/mono_context.cxx
@@ -9,30 +9,12 @@ import :poly_context;
 
 namespace lf {
 
-template <typename Context>
-class vector_adaptor {
- public:
-  constexpr void push(steal_handle<Context> value) { m_vector.push_back(value); }
-
-  constexpr auto pop() noexcept -> steal_handle<Context> {
-    if (!m_vector.empty()) {
-      steal_handle<Context> value = m_vector.back();
-      m_vector.pop_back();
-      return value;
-    }
-    return {};
-  }
-
- private:
-  std::vector<steal_handle<Context>> m_vector;
-};
-
 // TODO: allow customization of post (via Container?)
 // TODO: allocator aware
 
-export template <                                           //
-    worker_stack Stack,                                     //
-    template <typename> typename Container = vector_adaptor //
+export template <                        //
+    worker_stack Stack,                  //
+    template <typename> typename Adaptor //
     >
 class mono_context : public base_context<Stack> {
  public:
@@ -45,7 +27,7 @@ class mono_context : public base_context<Stack> {
   constexpr auto pop() noexcept -> steal_handle<context_type> { return m_container.pop(); }
 
   constexpr void post(sched_handle<context_type> handle) noexcept(noexcept(m_container.post(handle)))
-    requires requires (Container<context_type> context) {
+    requires requires (Adaptor<context_type> context) {
       { context.post(handle) } -> std::same_as<void>;
     }
   {
@@ -53,7 +35,7 @@ class mono_context : public base_context<Stack> {
   }
 
  private:
-  Container<context_type> m_container;
+  Adaptor<context_type> m_container;
 };
 
 } // namespace lf

--- a/src/core/mono_context.cxx
+++ b/src/core/mono_context.cxx
@@ -7,15 +7,15 @@ import :poly_context;
 
 namespace lf {
 
-template <typename T, typename Allocator>
+template <typename Context>
 class vector_stack {
 
  public:
-  constexpr void push(T value) { m_vector.push_back(value); }
+  constexpr void push(steal_handle<Context> value) { m_vector.push_back(value); }
 
-  constexpr auto pop() noexcept -> T {
+  constexpr auto pop() noexcept -> steal_handle<Context> {
     if (!m_vector.empty()) {
-      T value = m_vector.back();
+      steal_handle<Context> value = m_vector.back();
       m_vector.pop_back();
       return value;
     }
@@ -23,14 +23,14 @@ class vector_stack {
   }
 
  private:
-  std::vector<T, Allocator> m_vector;
+  std::vector<steal_handle<Context>> m_vector;
 };
 
 // TODO: allow customization of post (via Container?)
 
-export template <                                                   //
-    worker_stack Stack,                                             //
-    template <typename, typename> typename Container = vector_stack //
+export template <                                         //
+    worker_stack Stack,                                   //
+    template <typename> typename Container = vector_stack //
     >
 class mono_context : public base_context<Stack> {
 
@@ -42,12 +42,12 @@ class mono_context : public base_context<Stack> {
   using allocator_type = Stack::allocator_type;
   using allocator_traits = std::allocator_traits<allocator_type>;
 
-  using container_type = Container<steal_h, typename allocator_traits::template rebind_alloc<steal_h>>;
+  using container_type = Container<mono_context>;
 
  public:
-  constexpr void push(steal_h frame) { m_container.push(frame); }
+  constexpr void push(steal_handle<mono_context> frame) { m_container.push(frame); }
 
-  constexpr auto pop() noexcept -> steal_h { return m_container.pop(); }
+  constexpr auto pop() noexcept -> steal_handle<mono_context> { return m_container.pop(); }
 
   // TODO: make allocator aware
   // TODO: make generic over vector/deque

--- a/src/core/mono_context.cxx
+++ b/src/core/mono_context.cxx
@@ -5,11 +5,12 @@ import std;
 import :concepts;
 import :poly_context;
 
+// TODO: search for places that HOF would simplify
+
 namespace lf {
 
 template <typename Context>
 class vector_stack {
-
  public:
   constexpr void push(steal_handle<Context> value) { m_vector.push_back(value); }
 
@@ -27,33 +28,25 @@ class vector_stack {
 };
 
 // TODO: allow customization of post (via Container?)
+// TODO: allocator aware
 
 export template <                                         //
     worker_stack Stack,                                   //
     template <typename> typename Container = vector_stack //
     >
 class mono_context : public base_context<Stack> {
-
-  using sched_h = sched_handle<mono_context>;
-  using steal_h = steal_handle<mono_context>;
-
-  // TODO: Move some of these type defs into the base class
-
-  using allocator_type = Stack::allocator_type;
-  using allocator_traits = std::allocator_traits<allocator_type>;
-
-  using container_type = Container<mono_context>;
-
  public:
-  constexpr void push(steal_handle<mono_context> frame) { m_container.push(frame); }
+  constexpr void push(steal_handle<mono_context> frame) noexcept(noexcept(m_container.push(frame))) {
+    m_container.push(frame);
+  }
 
   constexpr auto pop() noexcept -> steal_handle<mono_context> { return m_container.pop(); }
 
-  // TODO: make allocator aware
-  // TODO: make generic over vector/deque
+  constexpr auto
+  post(sched_handle<mono_context> handle) noexcept(noexcept(m_container.post(handle))) -> void {}
 
  private:
-  container_type m_container;
+  Container<mono_context> m_container;
 };
 
 } // namespace lf

--- a/src/core/poly_context.cxx
+++ b/src/core/poly_context.cxx
@@ -56,9 +56,9 @@ class poly_context : public base_context<Stack> {
 // TODO: allocator aware
 // TODO: make post aware
 
-export template <                          //
-    worker_stack Stack,                    //
-    template <typename> typename Container //
+export template <                        //
+    worker_stack Stack,                  //
+    template <typename> typename Adaptor //
     >
 class derived_poly_context : public poly_context<Stack> {
  public:
@@ -69,7 +69,7 @@ class derived_poly_context : public poly_context<Stack> {
   constexpr auto pop() noexcept -> steal_handle<context_type> final { return m_container.pop(); }
 
   constexpr void post(sched_handle<context_type> handle)
-    requires requires (Container<context_type> context) {
+    requires requires (Adaptor<context_type> context) {
       { context.post(handle) } -> std::same_as<void>;
     }
   final {
@@ -77,7 +77,7 @@ class derived_poly_context : public poly_context<Stack> {
   }
 
  private:
-  Container<context_type> m_container;
+  Adaptor<context_type> m_container;
 };
 
 } // namespace lf

--- a/src/core/poly_context.cxx
+++ b/src/core/poly_context.cxx
@@ -55,8 +55,7 @@ class basic_poly_context : public basic_stack_context<Stack> {
  *  constructors that forward to the stack's constructors.
  */
 export template <bool Polymorphic, worker_stack Stack>
-using context_base = std::conditional_t<Polymorphic, basic_poly_context<Stack>, basic_stack_context<Stack>>;
-
-// export using poly_env = env<basic_poly_context<geometric_stack>>;
+using maybe_poly_context =
+    std::conditional_t<Polymorphic, basic_poly_context<Stack>, basic_stack_context<Stack>>;
 
 } // namespace lf

--- a/src/core/poly_context.cxx
+++ b/src/core/poly_context.cxx
@@ -68,12 +68,17 @@ class derived_poly_context : public poly_context<Stack> {
 
   constexpr auto pop() noexcept -> steal_handle<context_type> final { return m_container.pop(); }
 
-  constexpr void post(sched_handle<context_type> handle)
-    requires requires (Adaptor<context_type> context) {
-      { context.post(handle) } -> std::same_as<void>;
+  constexpr void post(sched_handle<context_type> handle) final {
+
+    constexpr bool has_post = requires {
+      { m_container.post(handle) } -> std::same_as<void>;
+    };
+
+    if constexpr (has_post) {
+      m_container.post(handle);
+    } else {
+      poly_context<Stack>::post(handle);
     }
-  final {
-    m_container.post(handle);
   }
 
  private:

--- a/src/core/poly_context.cxx
+++ b/src/core/poly_context.cxx
@@ -8,17 +8,17 @@ import :concepts;
 
 namespace lf {
 
-export template <worker_stack Stack>
-class basic_stack_context {
+template <worker_stack Stack>
+class context_stack_base {
  public:
   auto stack() noexcept -> Stack & { return m_stack; }
 
  protected:
-  constexpr basic_stack_context() = default;
+  constexpr context_stack_base() = default;
 
   template <typename... Args>
     requires std::constructible_from<Stack, Args...> && (sizeof...(Args) > 0)
-  explicit(sizeof...(Args) == 1) constexpr basic_stack_context(Args &&...args) noexcept(
+  explicit(sizeof...(Args) == 1) constexpr context_stack_base(Args &&...args) noexcept(
       std::is_nothrow_constructible_v<Stack, Args...>)
       : m_stack(std::forward<Args>(args)...) {}
 
@@ -30,11 +30,17 @@ export struct post_error : std::runtime_error {
   using std::runtime_error::runtime_error;
 };
 
+// TODO: rename basic_poly_context to poly_context
+
 /**
  * @brief A worker context polymorphic in push/pop/post.
+ *
+ * This is the canonical/blesses base class in libfork for polymorphic uses
+ * cases. Although possible, libfork does not recommend contexts polymorphic
+ * in the `.stack` member
  */
 export template <worker_stack Stack>
-class basic_poly_context : public basic_stack_context<Stack> {
+class basic_poly_context : public context_stack_base<Stack> {
  public:
   virtual void push(steal_handle<basic_poly_context>) = 0;
   virtual auto pop() noexcept -> steal_handle<basic_poly_context> = 0;
@@ -44,6 +50,42 @@ class basic_poly_context : public basic_stack_context<Stack> {
   }
 
   virtual ~basic_poly_context() noexcept = default;
+};
+
+// TODO: constraints on container
+
+// TODO: could we make the container non template-template
+// TODO: allocator aware
+// TODO: make post aware
+
+export template <                                    //
+    worker_stack Stack,                              //
+    template <typename, typename> typename Container //
+    >
+class generic_poly_context : public basic_poly_context<Stack> {
+
+  using sched_h = sched_handle<basic_poly_context<Stack>>;
+  using steal_h = steal_handle<basic_poly_context<Stack>>;
+
+  using allocator_type = Stack::allocator_type;
+  using allocator_traits = std::allocator_traits<allocator_type>;
+
+  using container_type = Container<steal_h, typename allocator_traits::template rebind_alloc<steal_h>>;
+
+ public:
+  constexpr void push(steal_h frame) final { m_container.push(frame); }
+
+  constexpr auto pop() noexcept -> steal_h final { return m_container.pop(); }
+
+  // constexpr void post(sched_h frame) {}
+
+  // TODO: make allocator aware
+  // TODO: make generic over vector/deque
+
+  // explicit constexpr inline_context(allocator_type const &) noexcept;
+
+ private:
+  container_type m_container;
 };
 
 /**
@@ -56,6 +98,6 @@ class basic_poly_context : public basic_stack_context<Stack> {
  */
 export template <bool Polymorphic, worker_stack Stack>
 using maybe_poly_context =
-    std::conditional_t<Polymorphic, basic_poly_context<Stack>, basic_stack_context<Stack>>;
+    std::conditional_t<Polymorphic, basic_poly_context<Stack>, context_stack_base<Stack>>;
 
 } // namespace lf

--- a/src/core/poly_context.cxx
+++ b/src/core/poly_context.cxx
@@ -56,42 +56,28 @@ class poly_context : public base_context<Stack> {
 // TODO: allocator aware
 // TODO: make post aware
 
-export template <                                    //
-    worker_stack Stack,                              //
-    template <typename, typename> typename Container //
+export template <                          //
+    worker_stack Stack,                    //
+    template <typename> typename Container //
     >
 class generic_poly_context : public poly_context<Stack> {
-
-  using sched_h = sched_handle<poly_context<Stack>>;
-  using steal_h = steal_handle<poly_context<Stack>>;
-
-  using allocator_type = Stack::allocator_type;
-  using allocator_traits = std::allocator_traits<allocator_type>;
-
-  using container_type = Container<steal_h, typename allocator_traits::template rebind_alloc<steal_h>>;
-
-  /*
-   *
-   * push/pop optionally post -> needs to know steal/sched handle types
-   *
-   * construct with what?
-   *
-   */
-
  public:
-  constexpr void push(steal_h frame) final { m_container.push(frame); }
+  using context_type = poly_context<Stack>;
 
-  constexpr auto pop() noexcept -> steal_h final { return m_container.pop(); }
+  constexpr void push(steal_handle<context_type> frame) final { m_container.push(frame); }
 
-  // constexpr void post(sched_h frame) {}
+  constexpr auto pop() noexcept -> steal_handle<context_type> final { return m_container.pop(); }
 
-  // TODO: make allocator aware
-  // TODO: make generic over vector/deque
-
-  // explicit constexpr inline_context(allocator_type const &) noexcept;
+  constexpr void post(sched_handle<context_type> handle)
+    requires requires (Container<context_type> context) {
+      { context.post(handle) } -> std::same_as<void>;
+    }
+  final {
+    m_container.post(handle);
+  }
 
  private:
-  container_type m_container;
+  Container<context_type> m_container;
 };
 
 } // namespace lf

--- a/src/core/poly_context.cxx
+++ b/src/core/poly_context.cxx
@@ -70,6 +70,14 @@ class generic_poly_context : public poly_context<Stack> {
 
   using container_type = Container<steal_h, typename allocator_traits::template rebind_alloc<steal_h>>;
 
+  /*
+   *
+   * push/pop optionally post -> needs to know steal/sched handle types
+   *
+   * construct with what?
+   *
+   */
+
  public:
   constexpr void push(steal_h frame) final { m_container.push(frame); }
 
@@ -85,16 +93,5 @@ class generic_poly_context : public poly_context<Stack> {
  private:
   container_type m_container;
 };
-
-/**
- * @brief A potentially polymorphic worker context base class.
- *
- * Provides:
- *  virtual push/pop/post/deleter if Polymorphic is true, otherwise provides no virtual functions.
- *  stack method/member.
- *  constructors that forward to the stack's constructors.
- */
-export template <bool Polymorphic, worker_stack Stack>
-using maybe_poly_context = std::conditional_t<Polymorphic, poly_context<Stack>, base_context<Stack>>;
 
 } // namespace lf

--- a/src/core/poly_context.cxx
+++ b/src/core/poly_context.cxx
@@ -9,17 +9,17 @@ import :concepts;
 namespace lf {
 
 template <worker_stack Stack>
-class context_stack_base {
+class base_context {
  public:
   auto stack() noexcept -> Stack & { return m_stack; }
 
  protected:
-  constexpr context_stack_base() = default;
+  constexpr base_context() = default;
 
   template <typename... Args>
     requires std::constructible_from<Stack, Args...> && (sizeof...(Args) > 0)
-  explicit(sizeof...(Args) == 1) constexpr context_stack_base(Args &&...args) noexcept(
-      std::is_nothrow_constructible_v<Stack, Args...>)
+  explicit(sizeof...(Args) ==
+           1) constexpr base_context(Args &&...args) noexcept(std::is_nothrow_constructible_v<Stack, Args...>)
       : m_stack(std::forward<Args>(args)...) {}
 
  private:
@@ -30,8 +30,6 @@ export struct post_error : std::runtime_error {
   using std::runtime_error::runtime_error;
 };
 
-// TODO: rename basic_poly_context to poly_context
-
 /**
  * @brief A worker context polymorphic in push/pop/post.
  *
@@ -40,16 +38,16 @@ export struct post_error : std::runtime_error {
  * in the `.stack` member
  */
 export template <worker_stack Stack>
-class basic_poly_context : public context_stack_base<Stack> {
+class poly_context : public base_context<Stack> {
  public:
-  virtual void push(steal_handle<basic_poly_context>) = 0;
-  virtual auto pop() noexcept -> steal_handle<basic_poly_context> = 0;
+  virtual void push(steal_handle<poly_context>) = 0;
+  virtual auto pop() noexcept -> steal_handle<poly_context> = 0;
 
-  virtual void post([[maybe_unused]] sched_handle<basic_poly_context> handle) {
+  virtual void post([[maybe_unused]] sched_handle<poly_context> handle) {
     LF_THROW(post_error{"Derived context does not support posting tasks."});
   }
 
-  virtual ~basic_poly_context() noexcept = default;
+  virtual ~poly_context() noexcept = default;
 };
 
 // TODO: constraints on container
@@ -62,10 +60,10 @@ export template <                                    //
     worker_stack Stack,                              //
     template <typename, typename> typename Container //
     >
-class generic_poly_context : public basic_poly_context<Stack> {
+class generic_poly_context : public poly_context<Stack> {
 
-  using sched_h = sched_handle<basic_poly_context<Stack>>;
-  using steal_h = steal_handle<basic_poly_context<Stack>>;
+  using sched_h = sched_handle<poly_context<Stack>>;
+  using steal_h = steal_handle<poly_context<Stack>>;
 
   using allocator_type = Stack::allocator_type;
   using allocator_traits = std::allocator_traits<allocator_type>;
@@ -97,7 +95,6 @@ class generic_poly_context : public basic_poly_context<Stack> {
  *  constructors that forward to the stack's constructors.
  */
 export template <bool Polymorphic, worker_stack Stack>
-using maybe_poly_context =
-    std::conditional_t<Polymorphic, basic_poly_context<Stack>, context_stack_base<Stack>>;
+using maybe_poly_context = std::conditional_t<Polymorphic, poly_context<Stack>, base_context<Stack>>;
 
 } // namespace lf

--- a/src/core/poly_context.cxx
+++ b/src/core/poly_context.cxx
@@ -60,7 +60,7 @@ export template <                          //
     worker_stack Stack,                    //
     template <typename> typename Container //
     >
-class generic_poly_context : public poly_context<Stack> {
+class derived_poly_context : public poly_context<Stack> {
  public:
   using context_type = poly_context<Stack>;
 

--- a/src/core/poly_context.cxx
+++ b/src/core/poly_context.cxx
@@ -33,7 +33,7 @@ export struct post_error : std::runtime_error {
 /**
  * @brief A worker context polymorphic in push/pop/post.
  *
- * This is the canonical/blesses base class in libfork for polymorphic uses
+ * This is the canonical/blessed base class in libfork for polymorphic uses
  * cases. Although possible, libfork does not recommend contexts polymorphic
  * in the `.stack` member
  */

--- a/src/core/promise.cxx
+++ b/src/core/promise.cxx
@@ -199,6 +199,8 @@ constexpr auto final_suspend(frame_t<Context> *frame) noexcept -> coro<> {
       // TODO: benchmark if this split/noinline regresses other in stealing context
       return final_suspend_continue(context, parent);
   }
+
+  LF_UNREACHABLE();
 }
 
 struct final_awaitable : std::suspend_always {

--- a/src/core/receiver.cxx
+++ b/src/core/receiver.cxx
@@ -28,7 +28,7 @@ struct receiver_state {
   std::atomic_flag m_ready;
 };
 
-template <typename T>
+export template <typename T>
 class receiver {
 
   using state_type = receiver_state<T>;

--- a/src/core/stacks/adaptor.cxx
+++ b/src/core/stacks/adaptor.cxx
@@ -1,0 +1,28 @@
+// export module libfork.core:adaptor_stack;
+//
+// import std;
+//
+// import :concepts;
+//
+// namespace lf::stacks {
+//
+// // TODO: use allocator
+//
+// export template <allocator_of<std::byte> Allocator = std::allocator<std::byte>>
+// struct adaptor {
+//
+//   using allocator_type = std::allocator<std::byte>;
+//
+//   struct ckpt {
+//     auto operator==(ckpt const &) const -> bool = default;
+//   };
+//
+//   constexpr static auto push(std::size_t sz) -> void * { return new std::byte[sz]; }
+//   constexpr static auto pop(void *p, std::size_t sz) noexcept -> void;
+//   constexpr static auto checkpoint() noexcept -> ckpt;
+//   constexpr static auto prepare_release() noexcept -> int;
+//   constexpr static auto release(int) noexcept -> void;
+//   constexpr static auto acquire(ckpt) noexcept -> void;
+// };
+//
+// } // namespace lf::stacks

--- a/src/schedule/inline.cxx
+++ b/src/schedule/inline.cxx
@@ -12,15 +12,12 @@ namespace lf {
 
 // TODO: Can we store the context directly in TLS?
 
-
 export template <derived_worker_context Context>
 class inline_scheduler {
  public:
   using context_type = Context::context_type;
 
-  auto post(lf::sched_handle<Context> handle) { 
-    // execute(m_context, handle);
-  }
+  auto post(lf::sched_handle<Context> handle) { execute(m_context, handle); }
 
  private:
   Context m_context;

--- a/src/schedule/inline.cxx
+++ b/src/schedule/inline.cxx
@@ -12,15 +12,15 @@ namespace lf {
 
 // TODO: Can we store the context directly in TLS?
 
-export template <worker_context Context>
+
+export template <derived_worker_context Context>
 class inline_scheduler {
-
-  // TODO: how to adapt for polymorphic contexts?
-
  public:
-  using context_type = Context;
+  using context_type = Context::context_type;
 
-  auto post(lf::sched_handle<Context> handle) { execute(m_context, handle); }
+  auto post(lf::sched_handle<Context> handle) { 
+    // execute(m_context, handle);
+  }
 
  private:
   Context m_context;

--- a/src/schedule/inline.cxx
+++ b/src/schedule/inline.cxx
@@ -17,7 +17,9 @@ class inline_scheduler {
  public:
   using context_type = Context::context_type;
 
-  auto post(lf::sched_handle<Context> handle) { execute(m_context, handle); }
+  void post(lf::sched_handle<context_type> handle) {
+    execute(static_cast<context_type &>(m_context), handle);
+  }
 
  private:
   Context m_context;

--- a/test/src/schedule.cpp
+++ b/test/src/schedule.cpp
@@ -39,7 +39,7 @@ TEST_CASE("Poly schedule", "[schedule]") {
 
   lf::inline_scheduler<context_type> scheduler;
 
-  // auto recv = schedule2(scheduler, void_function<context_type>);
+  auto recv = schedule2(scheduler, void_function<context_type>);
 
   // REQUIRE(recv.valid());
   // REQUIRE(std::move(recv).get() == true);

--- a/test/src/schedule.cpp
+++ b/test/src/schedule.cpp
@@ -28,7 +28,6 @@ TEST_CASE("Simple schedule", "[schedule]") {
   lf::inline_scheduler<context_type> scheduler;
 
   auto recv = schedule2(scheduler, void_function<context_type>);
-
   REQUIRE(recv.valid());
   REQUIRE(std::move(recv).get() == true);
 }
@@ -41,8 +40,9 @@ TEST_CASE("Poly schedule", "[schedule]") {
 
   using context_type = derived_context::context_type;
 
-  auto recv = schedule2(scheduler, void_function<context_type>);
+  STATIC_REQUIRE(lf::worker_context<context_type>);
 
-  // REQUIRE(recv.valid());
-  // REQUIRE(std::move(recv).get() == true);
+  auto recv = schedule2(scheduler, void_function<context_type>);
+  REQUIRE(recv.valid());
+  REQUIRE(std::move(recv).get() == true);
 }

--- a/test/src/schedule.cpp
+++ b/test/src/schedule.cpp
@@ -21,7 +21,9 @@ auto void_function(env<Context>) -> task<bool, Context> {
 
 TEST_CASE("Simple schedule", "[schedule]") {
 
-  using context_type = lf::generic_context<false, lf::stacks::geometric<>>;
+  using context_type = lf::generic_context<lf::stacks::geometric<>>;
+
+  STATIC_REQUIRE(lf::worker_context<context_type>);
 
   lf::inline_scheduler<context_type> scheduler;
 

--- a/test/src/schedule.cpp
+++ b/test/src/schedule.cpp
@@ -21,7 +21,7 @@ auto void_function(env<Context>) -> task<bool, Context> {
 
 TEST_CASE("Simple schedule", "[schedule]") {
 
-  using context_type = lf::mono_context<lf::stacks::geometric<>>;
+  using context_type = lf::mono_context<lf::stacks::geometric<>, lf::adapt_vector>;
 
   STATIC_REQUIRE(lf::worker_context<context_type>);
 

--- a/test/src/schedule.cpp
+++ b/test/src/schedule.cpp
@@ -21,7 +21,7 @@ auto void_function(env<Context>) -> task<bool, Context> {
 
 TEST_CASE("Simple schedule", "[schedule]") {
 
-  using context_type = lf::generic_context<lf::stacks::geometric<>>;
+  using context_type = lf::mono_context<lf::stacks::geometric<>>;
 
   STATIC_REQUIRE(lf::worker_context<context_type>);
 

--- a/test/src/schedule.cpp
+++ b/test/src/schedule.cpp
@@ -30,6 +30,17 @@ TEST_CASE("Simple schedule", "[schedule]") {
   auto recv = schedule2(scheduler, void_function<context_type>);
 
   REQUIRE(recv.valid());
-
   REQUIRE(std::move(recv).get() == true);
+}
+
+TEST_CASE("Poly schedule", "[schedule]") {
+
+  using context_type = lf::derived_poly_context<lf::stacks::geometric<>, lf::adapt_vector>;
+
+  lf::inline_scheduler<context_type> scheduler;
+
+  // auto recv = schedule2(scheduler, void_function<context_type>);
+
+  // REQUIRE(recv.valid());
+  // REQUIRE(std::move(recv).get() == true);
 }

--- a/test/src/schedule.cpp
+++ b/test/src/schedule.cpp
@@ -35,9 +35,11 @@ TEST_CASE("Simple schedule", "[schedule]") {
 
 TEST_CASE("Poly schedule", "[schedule]") {
 
-  using context_type = lf::derived_poly_context<lf::stacks::geometric<>, lf::adapt_vector>;
+  using derived_context = lf::derived_poly_context<lf::stacks::geometric<>, lf::adapt_vector>;
 
-  lf::inline_scheduler<context_type> scheduler;
+  lf::inline_scheduler<derived_context> scheduler;
+
+  using context_type = derived_context::context_type;
 
   auto recv = schedule2(scheduler, void_function<context_type>);
 


### PR DESCRIPTION
First working sketch of new schedule2 API, benchmarking the same as the previous API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new context implementations: `mono_context` and `derived_poly_context` for improved scheduling support.
  * Introduced `adapt_vector` and `adapt_deque` container adaptors for context-based scheduling.
  * Enhanced scheduler interface with improved context compatibility.

* **Documentation**
  * Added comprehensive module structure documentation describing core abstractions, APIs, and public modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->