### PR TITLE
[V4] Busy pool (dev version)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,7 @@ target_sources(libfork_libfork
       # libfork.schedulers
       src/schedulers/schedulers.cxx
       src/schedulers/inline.cxx
+      src/schedulers/busy.cxx
     PRIVATE
       src/exception.cpp
 )

--- a/benchmark/src/libfork_benchmark/fib/fib.hpp
+++ b/benchmark/src/libfork_benchmark/fib/fib.hpp
@@ -4,7 +4,7 @@
 
 import std;
 
-inline constexpr int fib_test = 3;
+inline constexpr int fib_test = 8;
 inline constexpr int fib_base = 37;
 
 /**

--- a/benchmark/src/libfork_benchmark/fib/libfork.cpp
+++ b/benchmark/src/libfork_benchmark/fib/libfork.cpp
@@ -39,7 +39,13 @@ void run(benchmark::State &state) {
 
   state.counters["n"] = static_cast<double>(n);
 
-  Sch scheduler{2};
+  Sch scheduler = [] -> Sch {
+    if constexpr (std::constructible_from<Sch, std::size_t>) {
+      return Sch{4};
+    } else {
+      return Sch{};
+    }
+  }();
 
   for (auto _ : state) {
     benchmark::DoNotOptimize(n);
@@ -70,13 +76,14 @@ using lf::inline_scheduler;
 using lf::adaptor_stack;
 using lf::geometric_stack;
 
-// BENCH_ALL(inline_scheduler<real_context<adaptor_stack<>, adapt_vector>>)
-// BENCH_ALL(inline_scheduler<poly_context<adaptor_stack<>, adapt_vector>>)
-//
-// BENCH_ALL(inline_scheduler<real_context<geometric_stack<>, adapt_vector>>)
-// BENCH_ALL(inline_scheduler<poly_context<geometric_stack<>, adapt_vector>>)
-//
-// BENCH_ALL(inline_scheduler<real_context<geometric_stack<>, adapt_deque>>)
-// BENCH_ALL(inline_scheduler<poly_context<geometric_stack<>, adapt_deque>>)
-//
+BENCH_ALL(inline_scheduler<real_context<adaptor_stack<>, adapt_vector>>)
+BENCH_ALL(inline_scheduler<poly_context<adaptor_stack<>, adapt_vector>>)
+
+BENCH_ALL(inline_scheduler<real_context<geometric_stack<>, adapt_vector>>)
+BENCH_ALL(inline_scheduler<poly_context<geometric_stack<>, adapt_vector>>)
+
+BENCH_ALL(inline_scheduler<real_context<geometric_stack<>, adapt_deque>>)
+BENCH_ALL(inline_scheduler<poly_context<geometric_stack<>, adapt_deque>>)
+
 BENCH_ALL(lf::busy_thread_pool<false, geometric_stack<>>)
+BENCH_ALL(lf::busy_thread_pool<true, geometric_stack<>>)

--- a/benchmark/src/libfork_benchmark/fib/libfork.cpp
+++ b/benchmark/src/libfork_benchmark/fib/libfork.cpp
@@ -88,5 +88,7 @@ BENCH_ALL(inline_scheduler<poly_context<geometric_stack<>, adapt_vector>>)
 BENCH_ALL(inline_scheduler<real_context<geometric_stack<>, adapt_deque>>)
 BENCH_ALL(inline_scheduler<poly_context<geometric_stack<>, adapt_deque>>)
 
+// TODO: bench over number of threads
+
 BENCH_ALL(lf::busy_thread_pool<false, geometric_stack<>>)
 BENCH_ALL(lf::busy_thread_pool<true, geometric_stack<>>)

--- a/benchmark/src/libfork_benchmark/fib/libfork.cpp
+++ b/benchmark/src/libfork_benchmark/fib/libfork.cpp
@@ -39,9 +39,9 @@ void run(benchmark::State &state) {
 
   state.counters["n"] = static_cast<double>(n);
 
-  Sch scheduler = [] -> Sch {
+  Sch scheduler = [&state] -> Sch {
     if constexpr (std::constructible_from<Sch, std::size_t>) {
-      return Sch{4};
+      return Sch{static_cast<std::size_t>(state.range(1))};
     } else {
       return Sch{};
     }
@@ -88,7 +88,22 @@ BENCH_ALL(inline_scheduler<poly_context<geometric_stack<>, adapt_vector>>)
 BENCH_ALL(inline_scheduler<real_context<geometric_stack<>, adapt_deque>>)
 BENCH_ALL(inline_scheduler<poly_context<geometric_stack<>, adapt_deque>>)
 
-// TODO: bench over number of threads
+// clang-format off
 
-BENCH_ALL(lf::busy_thread_pool<false, geometric_stack<>>)
-BENCH_ALL(lf::busy_thread_pool<true, geometric_stack<>>)
+#define BENCH_ONE_MT(mode, ...)                                                                                \
+  BENCHMARK_TEMPLATE(run, __VA_ARGS__)                                                                         \
+      ->Name(#mode "/libfork/fib/" #__VA_ARGS__)                                                               \
+      ->Apply([](benchmark::internal::Benchmark *b) {                                                          \
+        auto max_t = std::thread::hardware_concurrency();                                                      \
+        for (unsigned t = 1; t <= max_t; ++t) {                                                                \
+          b->Args({fib_##mode, static_cast<std::int64_t>(t)});                                                 \
+        }                                                                                                      \
+      })                                                                                                       \
+      ->UseRealTime();
+
+#define BENCH_ALL_MT(...) BENCH_ONE_MT(test, __VA_ARGS__) BENCH_ONE_MT(base, __VA_ARGS__)
+
+// clang-format on
+
+BENCH_ALL_MT(lf::busy_thread_pool<false, geometric_stack<>>)
+BENCH_ALL_MT(lf::busy_thread_pool<true, geometric_stack<>>)

--- a/benchmark/src/libfork_benchmark/fib/libfork.cpp
+++ b/benchmark/src/libfork_benchmark/fib/libfork.cpp
@@ -59,7 +59,10 @@ void run(benchmark::State &state) {
 } // namespace
 
 #define BENCH_ONE(mode, ...)                                                                                 \
-  BENCHMARK_TEMPLATE(run, __VA_ARGS__)->Name(#mode "/libfork/fib/" #__VA_ARGS__)->Arg(fib_##mode)->UseRealTime();
+  BENCHMARK_TEMPLATE(run, __VA_ARGS__)                                                                       \
+      ->Name(#mode "/libfork/fib/" #__VA_ARGS__)                                                             \
+      ->Arg(fib_##mode)                                                                                      \
+      ->UseRealTime();
 
 #define BENCH_ALL(...) BENCH_ONE(test, __VA_ARGS__) BENCH_ONE(base, __VA_ARGS__)
 

--- a/benchmark/src/libfork_benchmark/fib/libfork.cpp
+++ b/benchmark/src/libfork_benchmark/fib/libfork.cpp
@@ -88,22 +88,19 @@ BENCH_ALL(inline_scheduler<poly_context<geometric_stack<>, adapt_vector>>)
 BENCH_ALL(inline_scheduler<real_context<geometric_stack<>, adapt_deque>>)
 BENCH_ALL(inline_scheduler<poly_context<geometric_stack<>, adapt_deque>>)
 
-// clang-format off
+#define BENCH_MAX_THR 8
 
-#define BENCH_ONE_MT(mode, ...)                                                                                \
-  BENCHMARK_TEMPLATE(run, __VA_ARGS__)                                                                         \
-      ->Name(#mode "/libfork/fib/" #__VA_ARGS__)                                                               \
-      ->Apply([](benchmark::internal::Benchmark *b) {                                                          \
-        auto max_t = std::thread::hardware_concurrency();                                                      \
-        for (unsigned t = 1; t <= max_t; ++t) {                                                                \
-          b->Args({fib_##mode, static_cast<std::int64_t>(t)});                                                 \
-        }                                                                                                      \
-      })                                                                                                       \
+#define BENCH_ONE_MT(mode, ...)                                                                              \
+  BENCHMARK_TEMPLATE(run, __VA_ARGS__)                                                                       \
+      ->Name(#mode "/libfork/fib/" #__VA_ARGS__)                                                             \
+      ->Apply([](benchmark::Benchmark *b) -> void {                                                          \
+        for (unsigned t = 1; t <= BENCH_MAX_THR; ++t) {                                                      \
+          b->Args({fib_##mode, static_cast<std::int64_t>(t)});                                               \
+        }                                                                                                    \
+      })                                                                                                     \
       ->UseRealTime();
 
 #define BENCH_ALL_MT(...) BENCH_ONE_MT(test, __VA_ARGS__) BENCH_ONE_MT(base, __VA_ARGS__)
-
-// clang-format on
 
 BENCH_ALL_MT(lf::busy_thread_pool<false, geometric_stack<>>)
 BENCH_ALL_MT(lf::busy_thread_pool<true, geometric_stack<>>)

--- a/benchmark/src/libfork_benchmark/fib/libfork.cpp
+++ b/benchmark/src/libfork_benchmark/fib/libfork.cpp
@@ -39,7 +39,7 @@ void run(benchmark::State &state) {
 
   state.counters["n"] = static_cast<double>(n);
 
-  Sch scheduler;
+  Sch scheduler{2};
 
   for (auto _ : state) {
     benchmark::DoNotOptimize(n);
@@ -53,7 +53,7 @@ void run(benchmark::State &state) {
 } // namespace
 
 #define BENCH_ONE(mode, ...)                                                                                 \
-  BENCHMARK_TEMPLATE(run, __VA_ARGS__)->Name(#mode "/libfork/fib/" #__VA_ARGS__)->Arg(fib_##mode);
+  BENCHMARK_TEMPLATE(run, __VA_ARGS__)->Name(#mode "/libfork/fib/" #__VA_ARGS__)->Arg(fib_##mode)->UseRealTime();
 
 #define BENCH_ALL(...) BENCH_ONE(test, __VA_ARGS__) BENCH_ONE(base, __VA_ARGS__)
 
@@ -70,11 +70,13 @@ using lf::inline_scheduler;
 using lf::adaptor_stack;
 using lf::geometric_stack;
 
-BENCH_ALL(inline_scheduler<real_context<adaptor_stack<>, adapt_vector>>)
-BENCH_ALL(inline_scheduler<poly_context<adaptor_stack<>, adapt_vector>>)
-
-BENCH_ALL(inline_scheduler<real_context<geometric_stack<>, adapt_vector>>)
-BENCH_ALL(inline_scheduler<poly_context<geometric_stack<>, adapt_vector>>)
-
-BENCH_ALL(inline_scheduler<real_context<geometric_stack<>, adapt_deque>>)
-BENCH_ALL(inline_scheduler<poly_context<geometric_stack<>, adapt_deque>>)
+// BENCH_ALL(inline_scheduler<real_context<adaptor_stack<>, adapt_vector>>)
+// BENCH_ALL(inline_scheduler<poly_context<adaptor_stack<>, adapt_vector>>)
+//
+// BENCH_ALL(inline_scheduler<real_context<geometric_stack<>, adapt_vector>>)
+// BENCH_ALL(inline_scheduler<poly_context<geometric_stack<>, adapt_vector>>)
+//
+// BENCH_ALL(inline_scheduler<real_context<geometric_stack<>, adapt_deque>>)
+// BENCH_ALL(inline_scheduler<poly_context<geometric_stack<>, adapt_deque>>)
+//
+BENCH_ALL(lf::busy_thread_pool<false, geometric_stack<>>)

--- a/src/batteries/adaptor_stack.cxx
+++ b/src/batteries/adaptor_stack.cxx
@@ -33,7 +33,7 @@ class adaptor_stack {
   using size_int = align_trait::size_type;
 
   struct release_t {
-    explicit constexpr release_t(key_t) noexcept {}
+    explicit constexpr release_t(key_t /*unused*/) noexcept {}
   };
 
   class checkpoint_t {
@@ -48,7 +48,7 @@ class adaptor_stack {
     struct empty {
       constexpr empty() noexcept = default;
       constexpr auto operator==(empty const &) const noexcept -> bool = default;
-      explicit constexpr empty(align_alloc const &) noexcept {};
+      explicit constexpr empty(align_alloc const & /*unused*/) noexcept {}
     };
 
     std::conditional_t<align_trait::is_always_equal::value, empty, align_alloc> m_alloc;

--- a/src/batteries/adaptors.cxx
+++ b/src/batteries/adaptors.cxx
@@ -39,6 +39,8 @@ class adapt_deque {
     });
   }
 
+  constexpr auto thief() noexcept { return m_deque.thief(); }
+
  private:
   deque<steal_handle<Context>> m_deque{1024};
 };

--- a/src/batteries/adaptors.cxx
+++ b/src/batteries/adaptors.cxx
@@ -42,6 +42,7 @@ class adapt_deque {
   constexpr auto thief() noexcept { return m_deque.thief(); }
 
  private:
+  // TODO: make initializable/configurable
   deque<steal_handle<Context>> m_deque{1024};
 };
 

--- a/src/batteries/adaptors.cxx
+++ b/src/batteries/adaptors.cxx
@@ -39,7 +39,17 @@ class adapt_deque {
     });
   }
 
-  constexpr auto thief() noexcept { return m_deque.thief(); }
+  // TODO: vet for [[nodiscard]]
+
+  [[nodiscard]]
+  constexpr auto thief() noexcept {
+    return m_deque.thief();
+  }
+
+  [[nodiscard]]
+  constexpr auto empty() const noexcept -> bool {
+    return m_deque.empty();
+  }
 
  private:
   // TODO: make initializable/configurable

--- a/src/batteries/contexts.cxx
+++ b/src/batteries/contexts.cxx
@@ -24,7 +24,10 @@ class derived_poly_context : public poly_context<Stack> {
  public:
   using context_type = poly_context<Stack>;
 
-  constexpr auto get_underlying() noexcept -> Adaptor<context_type> & { return m_container; }
+  [[nodiscard]]
+  constexpr auto get_underlying() noexcept -> Adaptor<context_type> & {
+    return m_container;
+  }
 
   constexpr void push(steal_handle<context_type> frame) final { m_container.push(frame); }
 
@@ -58,7 +61,10 @@ class mono_context : public base_context<Stack> {
  public:
   using context_type = mono_context;
 
-  constexpr auto get_underlying() noexcept -> Adaptor<context_type> & { return m_container; }
+  [[nodiscard]]
+  constexpr auto get_underlying() noexcept -> Adaptor<context_type> & {
+    return m_container;
+  }
 
   constexpr void push(steal_handle<context_type> frame) noexcept(noexcept(m_container.push(frame))) {
     m_container.push(frame);

--- a/src/batteries/contexts.cxx
+++ b/src/batteries/contexts.cxx
@@ -24,6 +24,8 @@ class derived_poly_context : public poly_context<Stack> {
  public:
   using context_type = poly_context<Stack>;
 
+  constexpr auto get_underlying() noexcept -> Adaptor<context_type> & { return m_container; }
+
   constexpr void push(steal_handle<context_type> frame) final { m_container.push(frame); }
 
   constexpr auto pop() noexcept -> steal_handle<context_type> final { return m_container.pop(); }
@@ -55,6 +57,8 @@ export template <                        //
 class mono_context : public base_context<Stack> {
  public:
   using context_type = mono_context;
+
+  constexpr auto get_underlying() noexcept -> Adaptor<context_type> & { return m_container; }
 
   constexpr void push(steal_handle<context_type> frame) noexcept(noexcept(m_container.push(frame))) {
     m_container.push(frame);

--- a/src/batteries/geometric_stack.cxx
+++ b/src/batteries/geometric_stack.cxx
@@ -131,9 +131,9 @@ class geometric_stack {
    */
   constexpr void pop(void_ptr ptr, [[maybe_unused]] std::size_t n) noexcept {
 
-    LF_ASSUME(!empty());
     LF_ASSUME(m_ctrl != nullptr);
     LF_ASSUME(m_ctrl->top != nullptr);
+    LF_ASSUME(!empty());
     LF_ASSUME(m_sp != nullptr);
     LF_ASSUME(ptr != nullptr);
 

--- a/src/batteries/geometric_stack.cxx
+++ b/src/batteries/geometric_stack.cxx
@@ -50,9 +50,6 @@ class geometric_stack {
   };
 
  public:
-  // TODO: remove this typedef
-  using allocator_type = Allocator;
-
   constexpr geometric_stack() noexcept(noexcept(Allocator{})) : geometric_stack(Allocator()) {}
   explicit constexpr geometric_stack(Allocator const &alloc) noexcept : m_ctrl_alloc(alloc) {}
 

--- a/src/core/execute.cxx
+++ b/src/core/execute.cxx
@@ -52,9 +52,10 @@ export struct steal_overflow_error final : libfork_exception {
   }
 };
 
-
 export template <worker_context Context>
 constexpr void execute(Context &context, steal_handle<Context> handle) {
+
+  std::println("{} -> steal", std::this_thread::get_id());
 
   if (thread_local_context<Context> != nullptr) {
     LF_THROW(execute_error{});

--- a/src/core/execute.cxx
+++ b/src/core/execute.cxx
@@ -52,7 +52,6 @@ export struct steal_overflow_error final : libfork_exception {
   }
 };
 
-
 export template <worker_context Context>
 constexpr void execute(Context &context, steal_handle<Context> handle) {
 

--- a/src/core/execute.cxx
+++ b/src/core/execute.cxx
@@ -45,4 +45,36 @@ constexpr void execute(Context &context, sched_handle<Context> handle) {
   frame->handle().resume();
 }
 
+export struct steal_overflow_error final : libfork_exception {
+  [[nodiscard]]
+  constexpr auto what() const noexcept -> const char * override {
+    return "a single task has been stolen 65,535 times";
+  }
+};
+
+
+export template <worker_context Context>
+constexpr void execute(Context &context, steal_handle<Context> handle) {
+
+  if (thread_local_context<Context> != nullptr) {
+    LF_THROW(execute_error{});
+  }
+
+  thread_local_context<Context> = std::addressof(context);
+
+  defer _ = [] noexcept -> void {
+    thread_local_context<Context> = nullptr;
+  };
+
+  auto *frame = static_cast<frame_type<checkpoint_t<Context>> *>(get(key(), handle));
+
+  // TODO: bench if we should do this in debug only
+  if (frame->steals == k_u16_max) {
+    LF_THROW(steal_overflow_error{});
+  }
+
+  frame->steals += 1;
+  frame->handle().resume();
+}
+
 } // namespace lf

--- a/src/core/execute.cxx
+++ b/src/core/execute.cxx
@@ -52,10 +52,9 @@ export struct steal_overflow_error final : libfork_exception {
   }
 };
 
+
 export template <worker_context Context>
 constexpr void execute(Context &context, steal_handle<Context> handle) {
-
-  std::println("{} -> steal", std::this_thread::get_id());
 
   if (thread_local_context<Context> != nullptr) {
     LF_THROW(execute_error{});

--- a/src/core/promise.cxx
+++ b/src/core/promise.cxx
@@ -85,6 +85,8 @@ constexpr auto final_suspend(frame_t<Context> *frame) noexcept -> coro<> {
   // join race.
   bool const owner = parent->stack_ckpt == context.stack().checkpoint();
 
+  std::println("{} -> owner={}", std::this_thread::get_id(), owner);
+
   // TODO: we could reduce branching if we unconditionally release and also
   // drop pre-release function altogether... Need to benchmark with code that
   // triggers a lot of stealing.
@@ -114,6 +116,8 @@ constexpr auto final_suspend(frame_t<Context> *frame) noexcept -> coro<> {
     return parent->handle();
   }
 
+  std::println("{} -> lost", std::this_thread::get_id());
+
   // We did not win the join-race, we cannot dereference the parent pointer now
   // as the frame may now be freed by the winner. Parent has not reached join
   // or we are not the last child to complete. We are now out of jobs, we must
@@ -124,6 +128,8 @@ constexpr auto final_suspend(frame_t<Context> *frame) noexcept -> coro<> {
     // resuming thread will take ownership of the parent's we must give it up.
     context.stack().release(std::move(release_key));
   }
+
+  std::println("{} -> noop", std::this_thread::get_id());
 
   // Else, case (2), our stack has no allocations on it, it may be used later.
   return std::noop_coroutine();

--- a/src/core/promise.cxx
+++ b/src/core/promise.cxx
@@ -37,18 +37,20 @@ constexpr auto final_suspend(frame_t<Context> *frame) noexcept -> coro<> {
   LF_ASSUME(frame->joins == k_u16_max);
   LF_ASSUME(frame->exception_bit == 0);
 
-  // Before resuming the next (or exiting) we should clean-up the current frame.
-  defer _ = [frame] noexcept -> void {
-    frame->handle().destroy();
-  };
+  // Local copies (before we destroy frame)
+  category const kind = frame->kind;
 
   frame_t<Context> *parent = not_null(frame->parent);
 
-  if (frame->kind == category::call) {
+  // Before resuming the next (or exiting) we should clean-up the current frame.
+  // Can't use frame from this point onwards
+  frame->handle().destroy();
+
+  if (kind == category::call) {
     return parent->handle();
   }
 
-  LF_ASSUME(frame->kind == category::fork);
+  LF_ASSUME(kind == category::fork);
 
   Context &context = get_tls_context<Context>();
 

--- a/src/core/promise.cxx
+++ b/src/core/promise.cxx
@@ -87,8 +87,6 @@ constexpr auto final_suspend(frame_t<Context> *frame) noexcept -> coro<> {
   // join race.
   bool const owner = parent->stack_ckpt == context.stack().checkpoint();
 
-  std::println("{} -> owner={}", std::this_thread::get_id(), owner);
-
   // TODO: we could reduce branching if we unconditionally release and also
   // drop pre-release function altogether... Need to benchmark with code that
   // triggers a lot of stealing.
@@ -118,8 +116,6 @@ constexpr auto final_suspend(frame_t<Context> *frame) noexcept -> coro<> {
     return parent->handle();
   }
 
-  std::println("{} -> lost", std::this_thread::get_id());
-
   // We did not win the join-race, we cannot dereference the parent pointer now
   // as the frame may now be freed by the winner. Parent has not reached join
   // or we are not the last child to complete. We are now out of jobs, we must
@@ -130,8 +126,6 @@ constexpr auto final_suspend(frame_t<Context> *frame) noexcept -> coro<> {
     // resuming thread will take ownership of the parent's we must give it up.
     context.stack().release(std::move(release_key));
   }
-
-  std::println("{} -> noop", std::this_thread::get_id());
 
   // Else, case (2), our stack has no allocations on it, it may be used later.
   return std::noop_coroutine();

--- a/src/exception.cpp
+++ b/src/exception.cpp
@@ -9,7 +9,7 @@ namespace lf::impl {
 [[noreturn]]
 void terminate_with(char const *message, char const *file, int line) noexcept {
   LF_TRY {
-    std::println(stderr, "{}:{}: {}", file, line, message);
+    std::println(stderr, "{} {}:{}: {}", std::this_thread::get_id(), file, line, message);
   } LF_CATCH_ALL {
     // Drop exceptions during termination
   }

--- a/src/schedulers/busy.cxx
+++ b/src/schedulers/busy.cxx
@@ -30,6 +30,8 @@ class busy_thread_pool {
  public:
   using context_type = context::context_type;
 
+  // TODO: sleep when zero work
+
   explicit busy_thread_pool(std::size_t n = std::thread::hardware_concurrency()) : m_contexts(n) {
 
     if (n < 1) {

--- a/src/schedulers/busy.cxx
+++ b/src/schedulers/busy.cxx
@@ -71,7 +71,7 @@ class busy_scheduler {
 
     auto const n = m_contexts.size();
 
-    std::minstd_rand rng(static_cast<unsigned>(id + 1));
+    std::default_random_engine rng(static_cast<unsigned>(id + 1));
 
     while (!stop.stop_requested()) {
 

--- a/src/schedulers/busy.cxx
+++ b/src/schedulers/busy.cxx
@@ -82,7 +82,7 @@ class busy_thread_pool {
       LF_ASSUME(ctx.get_underlying().empty()); // ctx interactions are core-managed
 
       if (auto lock = std::unique_lock(m_mutex); !m_posted.empty()) {
-        auto task = m_posted.back();
+        sched_handle task = m_posted.back();
         m_posted.pop_back();
         lock.unlock();
         execute(static_cast<context_type &>(ctx), task);
@@ -101,9 +101,8 @@ class busy_thread_pool {
           LF_ASSUME(victim < n);
           LF_ASSUME(victim != id);
 
-          if (auto result = m_contexts[victim].get_underlying().thief().steal()) {
-            // resume(*result);
-            LF_UNREACHABLE(); // TODO:
+          if (auto [err, result] = m_contexts[victim].get_underlying().thief().steal()) {
+            execute(static_cast<context_type &>(ctx), result);
             continue;
           }
         }

--- a/src/schedulers/busy.cxx
+++ b/src/schedulers/busy.cxx
@@ -1,4 +1,5 @@
 module;
+#include "libfork/__impl/assume.hpp"
 #include "libfork/__impl/compiler.hpp"
 export module libfork.schedulers:busy_scheduler;
 
@@ -65,66 +66,49 @@ class busy_scheduler {
  private:
   void worker(std::stop_token stop, std::size_t id) {
 
-    auto &ctx = m_contexts[id];
+    LF_ASSUME(id < m_contexts.size());
 
-    thread_local_context<context_type> = static_cast<context_type *>(&ctx);
+    context &ctx = m_contexts[id];
 
-    defer cleanup = [] noexcept -> auto {
-      thread_local_context<context_type> = nullptr;
-    };
-
-    auto const n = m_contexts.size();
+    std::size_t const n = m_contexts.size();
 
     std::default_random_engine rng(static_cast<unsigned>(id + 1));
+    std::uniform_int_distribution<std::size_t> dist(0, n - 2);
+
+    constexpr int k_steal_attempts = 1024;
 
     while (!stop.stop_requested()) {
 
-      // 1. Pop from own deque.
-      if (auto task = ctx.pop()) {
+      LF_ASSUME(!ctx.empty()); // ctx interactions are core-managed
+
+      if (auto lock = std::unique_lock(m_mutex); !m_posted.empty()) {
+        auto task = m_posted.back();
+        m_posted.pop_back();
+        lock.unlock();
         resume(task);
-        continue;
       }
 
-      // 2. Check the posted queue for new root tasks.
-      {
-        auto lock = std::unique_lock(m_mutex);
-        if (!m_posted.empty()) {
-          auto task = m_posted.back();
-          m_posted.pop_back();
-          lock.unlock();
-          resume(task);
-          continue;
-        }
-      }
+      for (int i = 0; i < k_steal_attempts; ++i) {
 
-      // 3. Try stealing from a random other worker.
-      if (n > 1) {
-        auto victim = std::uniform_int_distribution<std::size_t>(0, n - 2)(rng);
+        std::size_t victim = dist(rng);
+
         if (victim >= id) {
           ++victim;
         }
+
+        LF_ASSUME(victim < n);
+        LF_ASSUME(victim != id);
+
         if (auto result = m_contexts[victim].get_underlying().thief().steal()) {
           resume(*result);
           continue;
         }
       }
-
-      std::this_thread::yield();
     }
   }
 
   void join_all() {
     m_threads.clear(); // jthread calls stop and joins in destructor
-  }
-
-  static void resume(steal_handle<context_type> task) {
-    auto *frame = static_cast<frame_type<checkpoint_t<context_type>> *>(get(key(), task));
-    frame->handle().resume();
-  }
-
-  static void resume(sched_handle<context_type> task) {
-    auto *frame = static_cast<frame_type<checkpoint_t<context_type>> *>(get(key(), task));
-    frame->handle().resume();
   }
 
   std::vector<context> m_contexts;

--- a/src/schedulers/busy.cxx
+++ b/src/schedulers/busy.cxx
@@ -86,6 +86,7 @@ class busy_thread_pool {
         m_posted.pop_back();
         lock.unlock();
         execute(static_cast<context_type &>(ctx), task);
+        std::println("{} -> finished root", std::this_thread::get_id());
         continue;
       }
 

--- a/src/schedulers/busy.cxx
+++ b/src/schedulers/busy.cxx
@@ -79,13 +79,13 @@ class busy_scheduler {
 
     while (!stop.stop_requested()) {
 
-      LF_ASSUME(!ctx.empty()); // ctx interactions are core-managed
+      LF_ASSUME(ctx.get_underlying().empty()); // ctx interactions are core-managed
 
       if (auto lock = std::unique_lock(m_mutex); !m_posted.empty()) {
         auto task = m_posted.back();
         m_posted.pop_back();
         lock.unlock();
-        resume(task);
+        execute(static_cast<context_type &>(ctx), task);
       }
 
       for (int i = 0; i < k_steal_attempts; ++i) {
@@ -100,7 +100,7 @@ class busy_scheduler {
         LF_ASSUME(victim != id);
 
         if (auto result = m_contexts[victim].get_underlying().thief().steal()) {
-          resume(*result);
+          // resume(*result);
           continue;
         }
       }

--- a/src/schedulers/busy.cxx
+++ b/src/schedulers/busy.cxx
@@ -2,25 +2,127 @@ export module libfork.schedulers:busy_scheduler;
 
 import std;
 
+import libfork.utils;
 import libfork.core;
 import libfork.batteries;
 
 namespace lf {
 
+template <typename Derived, typename Base>
+concept derived_context_from = worker_context<Base> && std::derived_from<Derived, Base>;
+
+template <typename Context>
+concept derived_worker_context =
+    has_context_typedef<Context> && derived_context_from<Context, context_t<Context>>;
+
 export template <bool Polymorphic, worker_stack Stack>
 class busy_scheduler {
 
-  using context = ; // TODO: derived_poly or mono_context
+  using context = std::conditional_t<           //
+      Polymorphic,                              //
+      derived_poly_context<Stack, adapt_deque>, //
+      mono_context<Stack, adapt_deque>          //
+      >;
+
+  static_assert(derived_worker_context<context>);
 
  public:
-  using context_type = ; // TODO:
+  using context_type = context::context_type;
 
-  void post(lf::sched_handle<context_type> handle) {
-    execute(static_cast<context_type &>(m_context), handle);
+  explicit busy_scheduler(std::size_t num_threads = std::thread::hardware_concurrency())
+      : m_contexts(num_threads) {
+    m_threads.reserve(num_threads);
+    for (std::size_t i = 0; i < num_threads; ++i) {
+      m_threads.emplace_back([this, i](std::stop_token stop) {
+        worker(stop, i);
+      });
+    }
+  }
+
+  ~busy_scheduler() {
+    for (auto &t : m_threads) {
+      t.request_stop();
+    }
+    for (auto &t : m_threads) {
+      t.join();
+    }
+  }
+
+  busy_scheduler(busy_scheduler const &) = delete;
+  busy_scheduler(busy_scheduler &&) = delete;
+  auto operator=(busy_scheduler const &) -> busy_scheduler & = delete;
+  auto operator=(busy_scheduler &&) -> busy_scheduler & = delete;
+
+  void post(sched_handle<context_type> handle) {
+    auto lock = std::unique_lock(m_mutex);
+    m_posted.push_back(handle);
   }
 
  private:
-  context m_context;
+  void worker(std::stop_token stop, std::size_t id) {
+
+    auto &ctx = m_contexts[id];
+
+    thread_local_context<context_type> = static_cast<context_type *>(&ctx);
+
+    defer cleanup = [] noexcept {
+      thread_local_context<context_type> = nullptr;
+    };
+
+    auto const n = m_contexts.size();
+
+    std::minstd_rand rng(static_cast<unsigned>(id + 1));
+
+    while (!stop.stop_requested()) {
+
+      // 1. Pop from own deque.
+      if (auto task = ctx.pop()) {
+        resume(task);
+        continue;
+      }
+
+      // 2. Check the posted queue for new root tasks.
+      {
+        auto lock = std::unique_lock(m_mutex);
+        if (!m_posted.empty()) {
+          auto task = m_posted.back();
+          m_posted.pop_back();
+          lock.unlock();
+          resume(task);
+          continue;
+        }
+      }
+
+      // 3. Try stealing from a random other worker.
+      if (n > 1) {
+        auto victim = std::uniform_int_distribution<std::size_t>(0, n - 2)(rng);
+        if (victim >= id) {
+          ++victim;
+        }
+        if (auto result = m_contexts[victim].get_underlying().thief().steal()) {
+          resume(*result);
+          continue;
+        }
+      }
+
+      std::this_thread::yield();
+    }
+  }
+
+  static void resume(steal_handle<context_type> task) {
+    auto *frame = static_cast<frame_type<checkpoint_t<context_type>> *>(get(key(), task));
+    frame->handle().resume();
+  }
+
+  static void resume(sched_handle<context_type> task) {
+    auto *frame = static_cast<frame_type<checkpoint_t<context_type>> *>(get(key(), task));
+    frame->handle().resume();
+  }
+
+  std::vector<context> m_contexts;
+  std::vector<std::jthread> m_threads;
+  std::mutex m_mutex;
+  std::vector<sched_handle<context_type>> m_posted;
 };
 
 } // namespace lf

--- a/src/schedulers/busy.cxx
+++ b/src/schedulers/busy.cxx
@@ -1,7 +1,7 @@
 module;
 #include "libfork/__impl/assume.hpp"
 #include "libfork/__impl/compiler.hpp"
-export module libfork.schedulers:busy_scheduler;
+export module libfork.schedulers:busy_thread_pool;
 
 import std;
 
@@ -19,7 +19,7 @@ struct invalid_workers_error : std::exception {
 };
 
 export template <bool Polymorphic, worker_stack Stack>
-class busy_scheduler {
+class busy_thread_pool {
 
   using context = std::conditional_t<           //
       Polymorphic,                              //
@@ -30,7 +30,7 @@ class busy_scheduler {
  public:
   using context_type = context::context_type;
 
-  explicit busy_scheduler(std::size_t n = std::thread::hardware_concurrency()) : m_contexts(n) {
+  explicit busy_thread_pool(std::size_t n = std::thread::hardware_concurrency()) : m_contexts(n) {
 
     if (n < 1) {
       LF_THROW(invalid_workers_error{});
@@ -49,13 +49,13 @@ class busy_scheduler {
     }
   }
 
-  busy_scheduler(busy_scheduler const &) = delete;
-  busy_scheduler(busy_scheduler &&) = delete;
+  busy_thread_pool(busy_thread_pool const &) = delete;
+  busy_thread_pool(busy_thread_pool &&) = delete;
 
-  auto operator=(busy_scheduler const &) -> busy_scheduler & = delete;
-  auto operator=(busy_scheduler &&) -> busy_scheduler & = delete;
+  auto operator=(busy_thread_pool const &) -> busy_thread_pool & = delete;
+  auto operator=(busy_thread_pool &&) -> busy_thread_pool & = delete;
 
-  ~busy_scheduler() { join_all(); }
+  ~busy_thread_pool() { join_all(); }
 
   void post(sched_handle<context_type> handle) {
     // TODO: use a lock-free queue here

--- a/src/schedulers/busy.cxx
+++ b/src/schedulers/busy.cxx
@@ -114,12 +114,7 @@ class busy_scheduler {
   }
 
   void join_all() {
-    for (auto &t : m_threads) {
-      t.request_stop();
-    }
-    for (auto &t : m_threads) {
-      t.join();
-    }
+    m_threads.clear(); // jthread calls stop and joins in destructor
   }
 
   static void resume(steal_handle<context_type> task) {

--- a/src/schedulers/busy.cxx
+++ b/src/schedulers/busy.cxx
@@ -9,15 +9,18 @@ namespace lf {
 
 export template <bool Polymorphic, worker_stack Stack>
 class busy_scheduler {
+
+  using context = ; // TODO: derived_poly or mono_context
+
  public:
-  using context_type = Context::context_type;
+  using context_type = ; // TODO:
 
   void post(lf::sched_handle<context_type> handle) {
     execute(static_cast<context_type &>(m_context), handle);
   }
 
  private:
-  Context m_context;
+  context m_context;
 };
 
 } // namespace lf

--- a/src/schedulers/busy.cxx
+++ b/src/schedulers/busy.cxx
@@ -1,0 +1,23 @@
+export module libfork.schedulers:busy_scheduler;
+
+import std;
+
+import libfork.core;
+import libfork.batteries;
+
+namespace lf {
+
+export template <bool Polymorphic, worker_stack Stack>
+class busy_scheduler {
+ public:
+  using context_type = Context::context_type;
+
+  void post(lf::sched_handle<context_type> handle) {
+    execute(static_cast<context_type &>(m_context), handle);
+  }
+
+ private:
+  Context m_context;
+};
+
+} // namespace lf

--- a/src/schedulers/busy.cxx
+++ b/src/schedulers/busy.cxx
@@ -86,7 +86,6 @@ class busy_thread_pool {
         m_posted.pop_back();
         lock.unlock();
         execute(static_cast<context_type &>(ctx), task);
-        std::println("{} -> finished root", std::this_thread::get_id());
         continue;
       }
 

--- a/src/schedulers/busy.cxx
+++ b/src/schedulers/busy.cxx
@@ -72,7 +72,7 @@ class busy_scheduler {
 
     std::size_t const n = m_contexts.size();
 
-    std::default_random_engine rng(static_cast<unsigned>(id + 1));
+    std::default_random_engine rng(safe_cast<unsigned>(id + 1));
     std::uniform_int_distribution<std::size_t> dist(0, n - 2);
 
     constexpr int k_steal_attempts = 1024;
@@ -86,22 +86,26 @@ class busy_scheduler {
         m_posted.pop_back();
         lock.unlock();
         execute(static_cast<context_type &>(ctx), task);
+        continue;
       }
 
-      for (int i = 0; i < k_steal_attempts; ++i) {
+      if (n > 1) {
+        for (int i = 0; i < k_steal_attempts; ++i) {
 
-        std::size_t victim = dist(rng);
+          std::size_t victim = dist(rng);
 
-        if (victim >= id) {
-          ++victim;
-        }
+          if (victim >= id) {
+            victim += 1;
+          }
 
-        LF_ASSUME(victim < n);
-        LF_ASSUME(victim != id);
+          LF_ASSUME(victim < n);
+          LF_ASSUME(victim != id);
 
-        if (auto result = m_contexts[victim].get_underlying().thief().steal()) {
-          // resume(*result);
-          continue;
+          if (auto result = m_contexts[victim].get_underlying().thief().steal()) {
+            // resume(*result);
+            LF_UNREACHABLE(); // TODO:
+            continue;
+          }
         }
       }
     }

--- a/src/schedulers/busy.cxx
+++ b/src/schedulers/busy.cxx
@@ -1,3 +1,5 @@
+module;
+#include "libfork/__impl/compiler.hpp"
 export module libfork.schedulers:busy_scheduler;
 
 import std;
@@ -8,12 +10,12 @@ import libfork.batteries;
 
 namespace lf {
 
-template <typename Derived, typename Base>
-concept derived_context_from = worker_context<Base> && std::derived_from<Derived, Base>;
-
-template <typename Context>
-concept derived_worker_context =
-    has_context_typedef<Context> && derived_context_from<Context, context_t<Context>>;
+struct invalid_workers_error : std::exception {
+  [[nodiscard]]
+  constexpr auto what() const noexcept -> const char * override {
+    return "A thread pool must have at least one worker.";
+  }
+};
 
 export template <bool Polymorphic, worker_stack Stack>
 class busy_scheduler {
@@ -24,36 +26,38 @@ class busy_scheduler {
       mono_context<Stack, adapt_deque>          //
       >;
 
-  static_assert(derived_worker_context<context>);
-
  public:
   using context_type = context::context_type;
 
-  explicit busy_scheduler(std::size_t num_threads = std::thread::hardware_concurrency())
-      : m_contexts(num_threads) {
-    m_threads.reserve(num_threads);
-    for (std::size_t i = 0; i < num_threads; ++i) {
-      m_threads.emplace_back([this, i](std::stop_token stop) {
-        worker(stop, i);
-      });
-    }
-  }
+  explicit busy_scheduler(std::size_t n = std::thread::hardware_concurrency()) : m_contexts(n) {
 
-  ~busy_scheduler() {
-    for (auto &t : m_threads) {
-      t.request_stop();
+    if (n < 1) {
+      LF_THROW(invalid_workers_error{});
     }
-    for (auto &t : m_threads) {
-      t.join();
+
+    LF_TRY{
+      for (std::size_t id = 0; id < n; ++id) {
+        m_threads.emplace_back([this, id](std::stop_token stop) -> void {
+          worker(std::move(stop), id);
+        });
+      }
+    } LF_CATCH_ALL {
+      // Force joins before members (which threads reference) are destroyed.
+      join_all();
+      LF_RETHROW;
     }
   }
 
   busy_scheduler(busy_scheduler const &) = delete;
   busy_scheduler(busy_scheduler &&) = delete;
+
   auto operator=(busy_scheduler const &) -> busy_scheduler & = delete;
   auto operator=(busy_scheduler &&) -> busy_scheduler & = delete;
 
+  ~busy_scheduler() { join_all(); }
+
   void post(sched_handle<context_type> handle) {
+    // TODO: use a lock-free queue here
     auto lock = std::unique_lock(m_mutex);
     m_posted.push_back(handle);
   }
@@ -65,7 +69,7 @@ class busy_scheduler {
 
     thread_local_context<context_type> = static_cast<context_type *>(&ctx);
 
-    defer cleanup = [] noexcept {
+    defer cleanup = [] noexcept -> auto {
       thread_local_context<context_type> = nullptr;
     };
 
@@ -106,6 +110,15 @@ class busy_scheduler {
       }
 
       std::this_thread::yield();
+    }
+  }
+
+  void join_all() {
+    for (auto &t : m_threads) {
+      t.request_stop();
+    }
+    for (auto &t : m_threads) {
+      t.join();
     }
   }
 

--- a/src/schedulers/schedulers.cxx
+++ b/src/schedulers/schedulers.cxx
@@ -1,4 +1,4 @@
 export module libfork.schedulers;
 
 export import :inline_scheduler;
-export import :busy_scheduler;
+export import :busy_thread_pool;

--- a/src/schedulers/schedulers.cxx
+++ b/src/schedulers/schedulers.cxx
@@ -1,3 +1,4 @@
 export module libfork.schedulers;
 
 export import :inline_scheduler;
+export import :busy_scheduler;

--- a/test/src/schedule.cpp
+++ b/test/src/schedule.cpp
@@ -13,17 +13,17 @@ using lf::env;
 using lf::task;
 
 template <typename Context>
-auto simple_function(env<Context>) -> task<bool, Context> {
+auto simple_function(env<Context> /*unused*/) -> task<bool, Context> {
   co_return true;
 }
 
 template <typename Context>
-auto void_function(env<Context>) -> task<void, Context> {
+auto void_function(env<Context> /*unused*/) -> task<void, Context> {
   co_return;
 }
 
 template <typename Context>
-auto throwing_function(env<Context>) -> task<void, Context> {
+auto throwing_function(env<Context> /*unused*/) -> task<void, Context> {
   LF_THROW(std::runtime_error{"This function always throws"});
   co_return;
 }

--- a/test/src/schedule.cpp
+++ b/test/src/schedule.cpp
@@ -1,3 +1,4 @@
+#include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
 #include "libfork/__impl/exception.hpp"
@@ -29,47 +30,49 @@ auto throwing_function(env<Context>) -> task<void, Context> {
   co_return;
 }
 
-template <typename Context>
-void simple_tests(auto &scheduler) {
+template <typename Sch>
+void simple_tests(Sch &scheduler) {
   SECTION("void") {
-    auto recv = schedule(scheduler, void_function<Context>);
+    auto recv = schedule(scheduler, void_function<lf::context_t<Sch>>);
     REQUIRE(recv.valid());
     std::move(recv).get();
   }
 
   SECTION("non-void") {
-    auto recv = schedule(scheduler, simple_function<Context>);
+    auto recv = schedule(scheduler, simple_function<lf::context_t<Sch>>);
     REQUIRE(recv.valid());
     REQUIRE(std::move(recv).get() == true);
   }
 
 #if LF_COMPILER_EXCEPTIONS
   SECTION("throwing") {
-    auto recv = schedule(scheduler, throwing_function<Context>);
+    auto recv = schedule(scheduler, throwing_function<lf::context_t<Sch>>);
     REQUIRE(recv.valid());
     REQUIRE_THROWS_AS(std::move(recv).get(), std::runtime_error);
   }
 #endif
 }
 
+using mono_inline_ctx = lf::mono_context<lf::geometric_stack<>, lf::adapt_vector>;
+using poly_inline_ctx = lf::derived_poly_context<lf::geometric_stack<>, lf::adapt_vector>;
+
 } // namespace
 
-TEST_CASE("Mono schedule", "[schedule]") {
-
-  using context_type = lf::mono_context<lf::geometric_stack<>, lf::adapt_vector>;
-  STATIC_REQUIRE(lf::worker_context<context_type>);
-
-  lf::inline_scheduler<context_type> scheduler;
-  simple_tests<context_type>(scheduler);
+TEMPLATE_TEST_CASE("Inline schedule", "[schedule]", mono_inline_ctx, poly_inline_ctx) {
+  lf::inline_scheduler<TestType> scheduler;
+  simple_tests(scheduler);
 }
 
-TEST_CASE("Poly schedule", "[schedule]") {
+namespace {
 
-  using derived_context = lf::derived_poly_context<lf::geometric_stack<>, lf::adapt_vector>;
+using mono_busy_scheduler = lf::busy_scheduler<false, lf::geometric_stack<>>;
+using poly_busy_scheduler = lf::busy_scheduler<true, lf::geometric_stack<>>;
 
-  lf::inline_scheduler<derived_context> scheduler;
+} // namespace
 
-  using context_type = derived_context::context_type;
-  STATIC_REQUIRE(lf::worker_context<context_type>);
-  simple_tests<context_type>(scheduler);
+TEMPLATE_TEST_CASE("Busy schedule", "[schedule]", mono_busy_scheduler, poly_busy_scheduler) {
+  for (std::size_t thr = 1; thr < 4; ++thr) {
+    TestType scheduler{thr};
+    simple_tests(scheduler);
+  }
 }

--- a/test/src/schedule.cpp
+++ b/test/src/schedule.cpp
@@ -69,9 +69,11 @@ using poly_busy_thread_pool = lf::busy_thread_pool<true, lf::geometric_stack<>>;
 } // namespace
 
 TEMPLATE_TEST_CASE("Busy schedule", "[schedule]", mono_busy_thread_pool, poly_busy_thread_pool) {
+
+  STATIC_REQUIRE(lf::scheduler<TestType>);
+
   for (std::size_t thr = 1; thr < 4; ++thr) {
     TestType scheduler{thr};
-    STATIC_REQUIRE(lf::scheduler<TestType>);
     simple_tests(scheduler);
   }
 }

--- a/test/src/schedule.cpp
+++ b/test/src/schedule.cpp
@@ -9,8 +9,6 @@ import libfork;
 
 namespace {
 
-// TODO: test exceptions
-
 using lf::env;
 using lf::task;
 

--- a/test/src/schedule.cpp
+++ b/test/src/schedule.cpp
@@ -71,6 +71,7 @@ using poly_busy_thread_pool = lf::busy_thread_pool<true, lf::geometric_stack<>>;
 TEMPLATE_TEST_CASE("Busy schedule", "[schedule]", mono_busy_thread_pool, poly_busy_thread_pool) {
   for (std::size_t thr = 1; thr < 4; ++thr) {
     TestType scheduler{thr};
+    STATIC_REQUIRE(lf::scheduler<TestType>);
     simple_tests(scheduler);
   }
 }

--- a/test/src/schedule.cpp
+++ b/test/src/schedule.cpp
@@ -63,12 +63,12 @@ TEMPLATE_TEST_CASE("Inline schedule", "[schedule]", mono_inline_ctx, poly_inline
 
 namespace {
 
-using mono_busy_scheduler = lf::busy_scheduler<false, lf::geometric_stack<>>;
-using poly_busy_scheduler = lf::busy_scheduler<true, lf::geometric_stack<>>;
+using mono_busy_thread_pool = lf::busy_thread_pool<false, lf::geometric_stack<>>;
+using poly_busy_thread_pool = lf::busy_thread_pool<true, lf::geometric_stack<>>;
 
 } // namespace
 
-TEMPLATE_TEST_CASE("Busy schedule", "[schedule]", mono_busy_scheduler, poly_busy_scheduler) {
+TEMPLATE_TEST_CASE("Busy schedule", "[schedule]", mono_busy_thread_pool, poly_busy_thread_pool) {
   for (std::size_t thr = 1; thr < 4; ++thr) {
     TestType scheduler{thr};
     simple_tests(scheduler);


### PR DESCRIPTION
A stripped back busy pool, just for dev (missing lock free submission queue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `busy_thread_pool` scheduler for multi-threaded task execution with configurable worker threads.
  * Added new context accessor methods for internal state access.
  * Added `steal_overflow_error` exception for detecting steal operation thresholds.
  * Added new `execute()` overload supporting work stealing operations.

* **Improvements**
  * Enhanced error output to include thread ID for better debugging.

* **Breaking Changes**
  * Removed `allocator_type` typedef from `geometric_stack`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->